### PR TITLE
Fix Electron device-key crypto loading

### DIFF
--- a/src/runtime/main-payload.js
+++ b/src/runtime/main-payload.js
@@ -25,9 +25,30 @@
   const fs = builtin("fs");
   const path = builtin("path");
   const os = builtin("os");
-  const crypto = builtin("crypto");
   const childProcess = builtin("child_process");
   const Module = builtin("module");
+
+  function loadNodeCrypto() {
+    if (typeof Module.createRequire === "function" && typeof process.execPath === "string") {
+      try {
+        const candidate = Module.createRequire(process.execPath)("node:crypto");
+        if (
+          candidate != null &&
+          typeof candidate.createPrivateKey === "function" &&
+          typeof candidate.createPublicKey === "function" &&
+          typeof candidate.sign === "function" &&
+          (typeof candidate.generateKeyPair === "function" || typeof candidate.generateKeyPairSync === "function")
+        ) {
+          return candidate;
+        }
+      } catch {
+        // Fall through to the ordinary builtin lookup below.
+      }
+    }
+    return builtin("crypto");
+  }
+
+  const crypto = loadNodeCrypto();
 
   function bridgeError(code, message) {
     const error = new Error(message);
@@ -342,6 +363,23 @@
   }
 
   function generateP256Pair() {
+    if (typeof crypto.generateKeyPair !== "function") {
+      if (typeof crypto.generateKeyPairSync !== "function") {
+        return Promise.reject(bridgeError("KEY_GENERATION_UNAVAILABLE", "Node P-256 key generation is unavailable"));
+      }
+      try {
+        return Promise.resolve(crypto.generateKeyPairSync(
+          "ec",
+          {
+            namedCurve: "prime256v1",
+            privateKeyEncoding: { format: "der", type: "pkcs8" },
+            publicKeyEncoding: { format: "der", type: "spki" },
+          },
+        )).then(({ privateKey, publicKey }) => ({ privateKey, publicKey }));
+      } catch {
+        return Promise.reject(bridgeError("KEY_GENERATION_FAILED", "P-256 key generation failed"));
+      }
+    }
     return new Promise((resolve, reject) => {
       crypto.generateKeyPair(
         "ec",

--- a/src/runtime/main-payload.js
+++ b/src/runtime/main-payload.js
@@ -28,24 +28,38 @@
   const childProcess = builtin("child_process");
   const Module = builtin("module");
 
+  function supportsDeviceKeyCrypto(candidate) {
+    return (
+      candidate != null &&
+      typeof candidate.createPrivateKey === "function" &&
+      typeof candidate.createPublicKey === "function" &&
+      typeof candidate.randomUUID === "function" &&
+      typeof candidate.sign === "function" &&
+      typeof candidate.timingSafeEqual === "function" &&
+      (typeof candidate.generateKeyPair === "function" || typeof candidate.generateKeyPairSync === "function")
+    );
+  }
+
   function loadNodeCrypto() {
     if (typeof Module.createRequire === "function" && typeof process.execPath === "string") {
       try {
         const candidate = Module.createRequire(process.execPath)("node:crypto");
-        if (
-          candidate != null &&
-          typeof candidate.createPrivateKey === "function" &&
-          typeof candidate.createPublicKey === "function" &&
-          typeof candidate.sign === "function" &&
-          (typeof candidate.generateKeyPair === "function" || typeof candidate.generateKeyPairSync === "function")
-        ) {
+        if (supportsDeviceKeyCrypto(candidate)) {
           return candidate;
         }
       } catch {
         // Fall through to the ordinary builtin lookup below.
       }
     }
-    return builtin("crypto");
+    try {
+      const candidate = builtin("crypto");
+      if (supportsDeviceKeyCrypto(candidate)) {
+        return candidate;
+      }
+    } catch {
+      // Report one stable, capability-specific error below.
+    }
+    throw bridgeError("CRYPTO_UNAVAILABLE", "A complete Node crypto module is required for Windows device keys");
   }
 
   const crypto = loadNodeCrypto();

--- a/tests/CleanroomSelfTest.js
+++ b/tests/CleanroomSelfTest.js
@@ -216,36 +216,47 @@ async function legacyStoreTest(storePath) {
   return { keyIdMismatchRejected: true, migratedToSchemaVersion: 1, signatureVerified: true, unknownFieldRejected: true };
 }
 
-async function electronRestrictedCryptoFallbackTest(root, storePath) {
-  const restrictedCrypto = crypto.webcrypto;
-  assert.equal(typeof restrictedCrypto.generateKeyPair, "undefined");
-  assert.equal(typeof restrictedCrypto.createPrivateKey, "undefined");
+function hostBuiltin(name) {
+  if (typeof process.getBuiltinModule === "function") {
+    return process.getBuiltinModule(name);
+  }
+  return require(name);
+}
 
-  const processFacade = {
+function processFacade(getBuiltinModule) {
+  const facade = {
     env: process.env,
     execPath: process.execPath,
-    getBuiltinModule(name) {
-      if (name === "crypto" || name === "node:crypto") {
-        return restrictedCrypto;
-      }
-      return process.getBuiltinModule(name);
-    },
     pid: process.pid,
     platform: process.platform,
   };
-  const context = vm.createContext({
+  if (typeof getBuiltinModule === "function") {
+    facade.getBuiltinModule = getBuiltinModule;
+  }
+  return facade;
+}
+
+function loadBridgeInVm(root, { getBuiltinModule, requireBuiltin } = {}) {
+  const globals = {
     Buffer,
     clearTimeout,
     console,
-    process: processFacade,
+    process: processFacade(getBuiltinModule),
     setTimeout,
-  });
+  };
+  if (typeof requireBuiltin === "function") {
+    globals.require = requireBuiltin;
+  }
+  const context = vm.createContext(globals);
   context.globalThis = context;
   const source = fs.readFileSync(path.join(root, "..", "src", "runtime", "main-payload.js"), "utf8");
-  const bridge = vm.runInContext(source, context, { filename: "main-payload.js" });
+  return vm.runInContext(source, context, { filename: "main-payload.js" });
+}
+
+async function vmDeviceKeyLifecycle(bridge, storePath, payloadText) {
   const service = new bridge.DeviceKeyService({ storePath });
   const created = await service.createDeviceKey("allow_os_protected_nonextractable");
-  const payload = Buffer.from("electron-restricted-crypto", "utf8");
+  const payload = Buffer.from(payloadText, "utf8");
   const signed = await service.signDeviceKey(created.keyId, payload);
   const publicKey = crypto.createPublicKey({
     format: "der",
@@ -254,7 +265,67 @@ async function electronRestrictedCryptoFallbackTest(root, storePath) {
   });
   assert.equal(crypto.verify("sha256", payload, publicKey, Buffer.from(signed.signatureDerBase64, "base64")), true);
   await service.deleteDeviceKey(created.keyId);
+}
+
+function restrictedCryptoBuiltin(name) {
+  if (name === "crypto" || name === "node:crypto") {
+    return crypto.webcrypto;
+  }
+  return hostBuiltin(name);
+}
+
+async function electronRestrictedCryptoFallbackTest(root, storePath) {
+  assert.equal(typeof crypto.webcrypto.generateKeyPair, "undefined");
+  assert.equal(typeof crypto.webcrypto.createPrivateKey, "undefined");
+  const bridge = loadBridgeInVm(root, { getBuiltinModule: restrictedCryptoBuiltin });
+  await vmDeviceKeyLifecycle(bridge, storePath, "electron-restricted-crypto");
   return { nativeCryptoLoadedWithCreateRequire: true, signatureVerified: true };
+}
+
+async function nodeWithoutGetBuiltinModuleTest(root, storePath) {
+  const bridge = loadBridgeInVm(root, { requireBuiltin: restrictedCryptoBuiltin });
+  await vmDeviceKeyLifecycle(bridge, storePath, "node-without-get-builtin-module");
+  return { outerRequireFallbackVerified: true, signatureVerified: true };
+}
+
+async function synchronousKeyGenerationFallbackTest(root, storePath) {
+  const syncOnlyCrypto = Object.create(crypto);
+  Object.defineProperty(syncOnlyCrypto, "generateKeyPair", { value: undefined });
+  assert.equal(typeof syncOnlyCrypto.generateKeyPair, "undefined");
+  assert.equal(typeof syncOnlyCrypto.generateKeyPairSync, "function");
+
+  const moduleFacade = Object.create(hostBuiltin("module"));
+  Object.defineProperty(moduleFacade, "createRequire", {
+    value() {
+      return (name) => name === "node:crypto" ? syncOnlyCrypto : require(name);
+    },
+  });
+  const resolveBuiltin = (name) => {
+    if (name === "module" || name === "node:module") {
+      return moduleFacade;
+    }
+    return restrictedCryptoBuiltin(name);
+  };
+  const bridge = loadBridgeInVm(root, { getBuiltinModule: resolveBuiltin });
+  await vmDeviceKeyLifecycle(bridge, storePath, "synchronous-key-generation");
+  return { signatureVerified: true, synchronousGenerationVerified: true };
+}
+
+async function incompleteCryptoRejectionTest(root) {
+  const moduleFacade = Object.create(hostBuiltin("module"));
+  Object.defineProperty(moduleFacade, "createRequire", {
+    value() {
+      return () => crypto.webcrypto;
+    },
+  });
+  const resolveBuiltin = (name) => {
+    if (name === "module" || name === "node:module") {
+      return moduleFacade;
+    }
+    return restrictedCryptoBuiltin(name);
+  };
+  assert.throws(() => loadBridgeInVm(root, { getBuiltinModule: resolveBuiltin }), { code: "CRYPTO_UNAVAILABLE" });
+  return { incompleteCryptoRejected: true };
 }
 
 async function rendererPayloadTest(root) {
@@ -385,6 +456,9 @@ async function main() {
     ["malformed-store-preservation", () => malformedPreservationTest(path.join(tempDirectory, "malformed.json"))],
     ["legacy-pem-store", () => legacyStoreTest(path.join(tempDirectory, "legacy.json"))],
     ["electron-restricted-crypto-fallback", () => electronRestrictedCryptoFallbackTest(root, path.join(tempDirectory, "electron-crypto.json"))],
+    ["node-without-get-builtin-module", () => nodeWithoutGetBuiltinModuleTest(root, path.join(tempDirectory, "node-22-0.json"))],
+    ["synchronous-key-generation-fallback", () => synchronousKeyGenerationFallbackTest(root, path.join(tempDirectory, "sync-crypto.json"))],
+    ["incomplete-crypto-rejection", () => incompleteCryptoRejectionTest(root)],
     ["renderer-existing-and-delayed", () => rendererPayloadTest(root)],
     ["inspector-explicit-refusal", () => inspectorClosureTest(root, tempDirectory)],
   ];

--- a/tests/CleanroomSelfTest.js
+++ b/tests/CleanroomSelfTest.js
@@ -216,6 +216,47 @@ async function legacyStoreTest(storePath) {
   return { keyIdMismatchRejected: true, migratedToSchemaVersion: 1, signatureVerified: true, unknownFieldRejected: true };
 }
 
+async function electronRestrictedCryptoFallbackTest(root, storePath) {
+  const restrictedCrypto = crypto.webcrypto;
+  assert.equal(typeof restrictedCrypto.generateKeyPair, "undefined");
+  assert.equal(typeof restrictedCrypto.createPrivateKey, "undefined");
+
+  const processFacade = {
+    env: process.env,
+    execPath: process.execPath,
+    getBuiltinModule(name) {
+      if (name === "crypto" || name === "node:crypto") {
+        return restrictedCrypto;
+      }
+      return process.getBuiltinModule(name);
+    },
+    pid: process.pid,
+    platform: process.platform,
+  };
+  const context = vm.createContext({
+    Buffer,
+    clearTimeout,
+    console,
+    process: processFacade,
+    setTimeout,
+  });
+  context.globalThis = context;
+  const source = fs.readFileSync(path.join(root, "..", "src", "runtime", "main-payload.js"), "utf8");
+  const bridge = vm.runInContext(source, context, { filename: "main-payload.js" });
+  const service = new bridge.DeviceKeyService({ storePath });
+  const created = await service.createDeviceKey("allow_os_protected_nonextractable");
+  const payload = Buffer.from("electron-restricted-crypto", "utf8");
+  const signed = await service.signDeviceKey(created.keyId, payload);
+  const publicKey = crypto.createPublicKey({
+    format: "der",
+    key: Buffer.from(created.publicKeySpkiDerBase64, "base64"),
+    type: "spki",
+  });
+  assert.equal(crypto.verify("sha256", payload, publicKey, Buffer.from(signed.signatureDerBase64, "base64")), true);
+  await service.deleteDeviceKey(created.keyId);
+  return { nativeCryptoLoadedWithCreateRequire: true, signatureVerified: true };
+}
+
 async function rendererPayloadTest(root) {
   const avatarOverlay = {
     title: "Codex",
@@ -343,6 +384,7 @@ async function main() {
     ["create-sign-verify-delete", () => deviceKeyLifecycleTest(path.join(tempDirectory, "lifecycle.json"))],
     ["malformed-store-preservation", () => malformedPreservationTest(path.join(tempDirectory, "malformed.json"))],
     ["legacy-pem-store", () => legacyStoreTest(path.join(tempDirectory, "legacy.json"))],
+    ["electron-restricted-crypto-fallback", () => electronRestrictedCryptoFallbackTest(root, path.join(tempDirectory, "electron-crypto.json"))],
     ["renderer-existing-and-delayed", () => rendererPayloadTest(root)],
     ["inspector-explicit-refusal", () => inspectorClosureTest(root, tempDirectory)],
   ];


### PR DESCRIPTION
## What changed

- Load the full Node `crypto` module through `module.createRequire(process.execPath)` when Electron exposes only the Web Crypto surface through `process.getBuiltinModule("crypto")`.
- Validate every crypto capability used by the device-key bridge, including `randomUUID` and `timingSafeEqual`, and fail with `CRYPTO_UNAVAILABLE` when neither loading path is complete.
- Retain an explicit `generateKeyPairSync` fallback when asynchronous key generation is unavailable.
- Add regression coverage for Electron's restricted crypto object, Node 22.0-22.2 without `process.getBuiltinModule`, synchronous key generation, and incomplete crypto rejection.

## Why

On the affected Windows Electron build, remote-control enrollment reached the clean-room device-key bridge but failed with `crypto.generateKeyPair is not a function`. The injected main-process environment returned a restricted Web Crypto object rather than the complete Node crypto module, so no device key was created and the UI reported remote-control authorization failure.

## Impact

Windows controller enrollment can create, protect, sign with, and delete its P-256 device key while preserving the existing DPAPI-backed storage design. Node `>=22` compatibility remains intact, including releases before `process.getBuiltinModule` was introduced.

## Validation

- `npm test` passed on the current Node runtime.
- Clean-room runtime self-test passed 12/12.
- Node 22.2.0 clean-room runtime self-test passed 12/12.
- End-to-end enrollment was verified on Codex Desktop `26.721.4979.0`; Control other devices authorization completed and remained stable.
