### PR TITLE
Fix TrayHost bootstrap handshake with UTF-8 BOM on redirected stdin

### DIFF
--- a/src/trayhost/PipeProtocol.cs
+++ b/src/trayhost/PipeProtocol.cs
@@ -192,6 +192,12 @@ internal static class ProtocolCodec
     private static ProtocolFrame ReadFrame(Stream input, ProtocolDirection direction, bool bootstrap, byte[] key, ulong expectedEpoch, ulong expectedSequence)
     {
         byte[] header = ReadExact(input, HeaderSize);
+        if (bootstrap && header[0] == 0xEF && header[1] == 0xBB && header[2] == 0xBF)
+        {
+            Buffer.BlockCopy(header, 3, header, 0, HeaderSize - 3);
+            byte[] tail = ReadExact(input, 3);
+            Buffer.BlockCopy(tail, 0, header, HeaderSize - 3, 3);
+        }
         for (int i = 0; i < 4; i++) { if (header[i] != Magic[i]) { throw new ProtocolViolationException("frame magic is invalid"); } }
         ushort version = BitConverter.ToUInt16(header, 4);
         ushort typeValue = BitConverter.ToUInt16(header, 6);

--- a/tests/trayhost/TrayHostProtocolSelfTest.cs
+++ b/tests/trayhost/TrayHostProtocolSelfTest.cs
@@ -59,6 +59,21 @@ internal static class TrayHostProtocolSelfTest
         AssertTrue(threw, "bootstrap direction mismatch is rejected");
     }
 
+    private static void TestBootstrapAcceptsUtf8Preamble()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("hello");
+        MemoryStream frame = new MemoryStream();
+        ProtocolCodec.WriteBootstrap(frame, ProtocolFrame.Bootstrap(ProtocolDirection.ParentToHost, TrayHostMessageType.ParentHello, payload));
+        MemoryStream stream = new MemoryStream();
+        byte[] preamble = Encoding.UTF8.GetPreamble();
+        stream.Write(preamble, 0, preamble.Length);
+        byte[] bytes = frame.ToArray();
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Position = 0;
+        ProtocolFrame parsed = ProtocolCodec.ReadBootstrap(stream, ProtocolDirection.ParentToHost);
+        AssertEqual("hello", Encoding.UTF8.GetString(parsed.Payload), "bootstrap tolerates the redirected PowerShell UTF-8 preamble");
+    }
+
     private static void TestAuthenticatedFrameRejectsReplayAndTamper()
     {
         byte[] key = Enumerable.Repeat((byte)0x42, 32).ToArray();
@@ -118,10 +133,11 @@ internal static class TrayHostProtocolSelfTest
             TestRfc5869Expand();
             TestBootstrapFrameRoundTrip();
             TestBootstrapRejectsWrongDirection();
+            TestBootstrapAcceptsUtf8Preamble();
             TestAuthenticatedFrameRejectsReplayAndTamper();
             TestLargeEpochUsesUnsignedWireEncoding();
             TestPresentationSnapshotValidation();
-            Console.WriteLine("TrayHost protocol self-tests passed: 6");
+            Console.WriteLine("TrayHost protocol self-tests passed: 7");
             return 0;
         }
         catch (Exception error)


### PR DESCRIPTION
## Summary

Allow the initial TrayHost bootstrap frame to tolerate a single UTF-8 BOM (`EF BB BF`) before the protocol magic, and add a regression test for this Windows PowerShell redirection behavior.

## Root cause

The tray supervisor starts `CodexRemote.TrayHost.exe` with redirected standard input and communicates with it using the binary TrayHost protocol. A valid bootstrap frame normally begins with the four-byte magic:

```text
43 52 54 48  (CRTH)
```

On the affected Windows environment, the child process actually received:

```text
EF BB BF 43 52 54 48
```

The leading `EF BB BF` is a UTF-8 preamble emitted while the redirected stdin stream is initialized through Windows PowerShell 5.1 / .NET Framework. Because `ProtocolCodec.ReadFrame` expected `CRTH` at byte zero, the child rejected the first frame with `frame magic is invalid` and exited. The parent then observed EOF while waiting for the response and reported `truncated frame`, causing the persistent supervisor to exit before signaling readiness.

This was reproducible with CodexRemote-fix 2.4.15 on Windows 11. The existing protocol tests use `MemoryStream`, which starts directly with the protocol frame and therefore did not exercise the redirected-process preamble.

## Fix

For bootstrap frames only, detect exactly one standard UTF-8 BOM at the start of the stream, shift the already-read header bytes, and read the remaining three bytes before continuing through the existing parser.

The authenticated protocol remains unchanged. Magic validation, frame length, direction, epoch, sequence, payload validation, HMAC verification, and process identity checks are still enforced as before. Non-bootstrap frames do not accept a preamble.

## Tests

- Added `TestBootstrapAcceptsUtf8Preamble` to reproduce the observed byte stream.
- TrayHost protocol self-tests pass: 7/7.
- Production TrayHost compilation test passes.
- Verified the rebuilt runtime on the affected machine: the scheduled supervisor remains running and `CodexRemote.TrayHost.exe` completes the handshake successfully.