### PR TITLE
release: CodexRemote-fix v2.4.16 and Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CodexRemote-fix CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Windows validation
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Run repository validation
+        shell: pwsh
+        run: npm test
+
+      - name: Run TrayHost protocol self-test
+        shell: pwsh
+        run: ./tests/trayhost/Invoke-TrayHostSelfTest.ps1 -ProtocolOnly
+
+      - name: Run production TrayHost smoke test
+        shell: pwsh
+        run: ./tests/trayhost/Invoke-TrayHostSelfTest.ps1 -ProductionOnly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
 
       - name: Run repository validation
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ This file keeps the short bilingual summary for every published release.
 
 ## Unreleased
 
+No unreleased changes.
+
+## v2.4.16
+
 ### English
 
+- Fixed a Windows PowerShell redirected-input UTF-8 preamble that could make TrayHost exit before signaling readiness.
+- Kept strict protocol validation and limited the compatibility path to one BOM on the initial bootstrap frame only.
+- Added Windows GitHub Actions validation for pull requests and pushes to `main`.
 - Added a concise before/after showcase image of the real Control other devices tab.
 
 ### 简体中文
 
-- 新增真实“控制其他设备”标签的修复前后展示图。
+- 修复 Windows PowerShell 重定向输入中的 UTF-8 前导标记导致 TrayHost 在报告就绪前退出的问题。
+- 保持严格协议校验，仅允许初始 bootstrap 帧兼容一个 BOM，不放宽后续认证帧。
+- 新增 GitHub Actions Windows CI，检查 Pull Request 和推送到 `main` 的变更。
+- 新增真实“控制其他设备”标签的简洁修复前后展示图。
 
 ## v2.4.15
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.4.15-setup.exe` and `CodexRemote-fix-2.4.15-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.4.15-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.4.16-setup.exe` and `CodexRemote-fix-2.4.16-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.4.16-setup.exe`; no administrator rights are required.
+   Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. When the tray icon is green, open **Settings → Connections → Control other devices** to enroll or use the device.
 
 The current installer and its SHA-256 checksum are always published on the
@@ -49,13 +50,12 @@ Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
 
-## What's new in v2.4.15
+## What's new in v2.4.16
 
-- Rebuilt the tray surface as a compiled native Win32 TrayHost using the normal Windows context-menu behavior.
-- Added a product icon, Start-menu registration, and a **CodexRemote-fix** desktop shortcut.
-- Kept the tray menu bilingual: Follow system, 中文, and English, with in-place state updates.
-- Hardened startup/recovery so an interrupted upgrade can adopt one newly launched ordinary Codex instance without touching device keys.
-- Preserved the existing encrypted device-key store and server-side authorization.
+- Fixed a Windows PowerShell redirected-input UTF-8 preamble that could make TrayHost exit before signaling readiness.
+- Kept strict protocol validation: only the initial bootstrap frame accepts one BOM; authenticated frames remain unchanged.
+- Added Windows GitHub Actions validation for pull requests and pushes to `main`.
+- Preserved the existing native Win32 tray, encrypted device-key store, and server-side authorization.
 
 ## Everyday use
 
@@ -71,8 +71,8 @@ supervisor are working.
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.4.15 release includes the ready-to-run `CodexRemote-fix-2.4.15-setup.exe`
-and `CodexRemote-fix-2.4.15-setup.exe.sha256.txt`.
+so the 2.4.16 release includes the ready-to-run `CodexRemote-fix-2.4.16-setup.exe`
+and `CodexRemote-fix-2.4.16-setup.exe.sha256.txt`.
 
 Each release appends a short bilingual change summary to this README and to the GitHub release body.
 The full history is in [CHANGELOG.md](CHANGELOG.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,8 +30,9 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.15-setup.exe` 和 `CodexRemote-fix-2.4.15-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.4.15-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.16-setup.exe` 和 `CodexRemote-fix-2.4.16-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.4.16-setup.exe`，无需管理员权限。
+   Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。托盘图标为绿色时，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
 当前安装包及其 SHA-256 校验值始终发布在
@@ -42,13 +43,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
 
-## v2.4.15 更新内容
+## v2.4.16 更新内容
 
-- 托盘界面重构为编译后的原生 Win32 TrayHost，使用 Windows 默认右键菜单行为。
-- 新增产品图标、开始菜单注册和 **CodexRemote-fix** 桌面快捷方式。
-- 托盘菜单保持双语：跟随系统、中文、English，状态可原地更新。
-- 加固启动与恢复流程；升级中断后可安全接管新启动的普通 Codex，不触碰设备密钥。
-- 保留现有加密设备密钥和服务器端授权。
+- 修复 Windows PowerShell 重定向输入中的 UTF-8 前导标记导致 TrayHost 在报告就绪前退出的问题。
+- 保持严格协议校验：仅初始 bootstrap 帧兼容一个 BOM，后续认证帧不变。
+- 新增 GitHub Actions Windows CI，检查 Pull Request 和推送到 `main` 的变更。
+- 保留现有原生 Win32 托盘、加密设备密钥和服务器端授权。
 
 ## 日常使用
 
@@ -64,8 +64,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
 `.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此后续每次更新都会
-为 2.4.15 发布提供可直接运行的 `CodexRemote-fix-2.4.15-setup.exe`
-及 `CodexRemote-fix-2.4.15-setup.exe.sha256.txt`。
+为 2.4.16 发布提供可直接运行的 `CodexRemote-fix-2.4.16-setup.exe`
+及 `CodexRemote-fix-2.4.16-setup.exe.sha256.txt`。
 
 每次发布都会在本 README 和 GitHub Release 正文中追加简短的中英文更新说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/trayhost/AssemblyInfo.cs
+++ b/src/trayhost/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Persistent native tray host for CodexRemote-fix")]
 [assembly: AssemblyCompany("CodexRemote-fix contributors")]
 [assembly: AssemblyProduct("CodexRemote-fix")]
-[assembly: AssemblyVersion("2.4.15.0")]
-[assembly: AssemblyFileVersion("2.4.15.0")]
+[assembly: AssemblyVersion("2.4.16.0")]
+[assembly: AssemblyFileVersion("2.4.16.0")]
 [assembly: ComVisible(false)]

--- a/src/trayhost/CodexRemote.TrayHost.manifest
+++ b/src/trayhost/CodexRemote.TrayHost.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.4.15.0" name="CodexRemote.fix.TrayHost" type="win32" />
+  <assemblyIdentity version="2.4.16.0" name="CodexRemote.fix.TrayHost" type="win32" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1208,16 +1208,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A# CodexRemote-fix\r?\n') 'Chinese README uses the public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.15-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.15-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.16-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.16-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
-    $chineseSections = [regex]::Matches($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(.*?)(?=^## |\z)')
-    Assert-CcodTrue ($chineseSections.Count -ge 1) 'Chinese README exposes a first Quick Start section'
-    $quickStartChinese = $chineseSections[0].Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.15-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.15-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
+    Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
+    $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.16-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.16-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1112,19 +1112,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.15 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.16 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.4.15' ([string]$package.version) 'package version is exactly 2.4.15'
+    Assert-CcodEqual '2.4.16' ([string]$package.version) 'package version is exactly 2.4.16'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.4.15-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.16-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.4.15-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.16-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 $results += Invoke-CcodTest 'CodexRemote-fix icon is a bounded multi-resolution PNG ICO' {

--- a/tests/persistence/TrayHostBuild.SelfTest.ps1
+++ b/tests/persistence/TrayHostBuild.SelfTest.ps1
@@ -38,12 +38,12 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
     Import-Module $modulePath -Force
     $artifact=Join-Path $env:TEMP ('ccod-trayhost-artifact-'+[Guid]::NewGuid().ToString('N'))
     try{
-        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.4.15' -OutputDirectory $artifact
+        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.4.16' -OutputDirectory $artifact
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe') -PathType Leaf) 'TrayHost executable exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe.config') -PathType Leaf) 'TrayHost config exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -PathType Leaf) 'TrayHost provenance exists'
         $provenance=Get-Content -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -Raw|ConvertFrom-Json
-        Assert-CcodEqual '2.4.15' ([string]$provenance.version) 'provenance version is exact'
+        Assert-CcodEqual '2.4.16' ([string]$provenance.version) 'provenance version is exact'
         $icon=Join-Path $repositoryRoot 'assets\codexremote-fix\codexremote-fix.ico'
         Assert-CcodTrue (Test-Path -LiteralPath $icon -PathType Leaf) 'TrayHost product ICO exists'
         $iconSha=[Security.Cryptography.SHA256]::Create();try{$iconHash=([BitConverter]::ToString($iconSha.ComputeHash([IO.File]::ReadAllBytes($icon)))).Replace('-','').ToLowerInvariant()}finally{$iconSha.Dispose()}
@@ -51,7 +51,7 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
         Assert-CcodTrue (@($provenance.sourceFiles).Count -ge 10) 'provenance includes every TrayHost source'
         Assert-CcodTrue (-not ([string]$provenance|Select-String -Pattern '[A-Za-z]:\\|\\\\' -Quiet)) 'provenance does not leak absolute paths'
         $tampered=Join-Path $artifact 'CodexRemote.TrayHost.exe.config'; Add-Content -LiteralPath $tampered -Value 'x'
-        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.4.15' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
+        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.4.16' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
         Assert-CcodTrue $threw 'tampered artifact is rejected'
     }finally{if(Test-Path -LiteralPath $artifact){Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue}}
 }


### PR DESCRIPTION
## Summary

- Prepare CodexRemote-fix v2.4.16 after the TrayHost bootstrap BOM fix merged in PR #4.
- Add Windows GitHub Actions validation for pull requests and pushes to `main`.
- Update the bilingual README and CHANGELOG with the v2.4.16 installer and startup compatibility notes.
- Keep strict protocol validation and preserve the existing tray/device-key behavior.

## Validation

- TrayHost protocol self-test: 7/7 passed.
- TrayHost production smoke/build self-tests passed.
- Clean-room runtime self-test passed.
- Package checker self-test passed.
- Install lifecycle self-tests passed: 49.
- On the development machine, full `npm test` is blocked by the live installed supervisor holding the AccountTransition mutex; the same baseline failure reproduces on origin/main. GitHub Actions is the clean-runner gate for this PR.