### PR TITLE
release: CodexRemote-fix v2.4.19 about and safe upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This file keeps the short bilingual summary for every published release.
 
 No unreleased changes.
 
+## v2.4.19
+
+### English
+
+- Added a native About menu item that displays the active CodexRemote-fix version.
+- The installer now stops and verifies the running supervisor before replacing the installed runtime.
+- Preserved device keys and persistent state through the safe atomic runtime upgrade; old runtimes are retired after activation.
+
+### 简体中文
+
+- 新增原生“关于”菜单项，显示当前 CodexRemote-fix 版本。
+- 安装器替换已安装运行时前，会先停止并验证当前守护程序。
+- 安全的原子 runtime 升级会保留设备密钥和持久化状态，新运行时激活后才清理旧运行时。
+
 ## v2.4.18
 
 ### English

--- a/Prepare-CcodRemoteUpgrade.ps1
+++ b/Prepare-CcodRemoteUpgrade.ps1
@@ -1,0 +1,98 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$InstallRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-CcodUpgradeCanonicalPath {
+    param([Parameter(Mandatory)][string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not [IO.Path]::IsPathRooted($Path)) {
+        throw 'CCOD_UPGRADE_ROOT_INVALID'
+    }
+    return [IO.Path]::GetFullPath($Path).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+}
+
+function Get-CcodVerifiedSupervisor {
+    param([Parameter(Mandatory)][string]$Root)
+
+    $activePath = Join-Path $Root 'active.json'
+    $statusPath = Join-Path $Root 'state\status.json'
+    if (-not [IO.File]::Exists($activePath) -or -not [IO.File]::Exists($statusPath)) { return $null }
+
+    try {
+        $active = Get-Content -LiteralPath $activePath -Raw | ConvertFrom-Json -ErrorAction Stop
+        $status = Get-Content -LiteralPath $statusPath -Raw | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $active -or $active.activeRuntime -isnot [string] -or $active.activeRuntime -notmatch '^[A-Za-z0-9._-]{1,96}$' -or
+            $null -eq $status.session -or $status.session.supervisorPid -isnot [int] -or $status.session.supervisorPid -lt 1 -or
+            $status.session.supervisorCreationTimeUtc -isnot [string] -or $status.session.sessionId -isnot [string]) { return $null }
+        $sessionId = 0
+        if (-not [int]::TryParse($status.session.sessionId, [ref]$sessionId) -or $sessionId -lt 0) { return $null }
+        $expectedSupervisor = [IO.Path]::GetFullPath((Join-Path $Root ("runtime\{0}\src\persistence\Supervisor.ps1" -f $active.activeRuntime)))
+        if (-not [IO.File]::Exists($expectedSupervisor)) { return $null }
+        $process = Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f [int]$status.session.supervisorPid) -ErrorAction Stop
+        if ($null -eq $process -or [string]::IsNullOrWhiteSpace([string]$process.CommandLine)) { return $null }
+        $commandLine = [string]$process.CommandLine
+        if ($commandLine -notmatch [regex]::Escape($expectedSupervisor) -or $commandLine -notmatch '(?i)(?:^|\s)-ReadyToken\s+[0-9a-f]{64}(?=\s|$)') { return $null }
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        try {
+            if ($null -eq $identity -or $null -eq $identity.User) {
+                return $null
+            }
+            $owner = Invoke-CimMethod -InputObject $process -MethodName GetOwnerSid -ErrorAction Stop
+            if ($null -eq $owner -or [int]$owner.ReturnValue -ne 0 -or [string]$owner.Sid -cne $identity.User.Value) { return $null }
+            return [pscustomobject][ordered]@{
+                Pid = [int]$status.session.supervisorPid
+                CreationTimeUtc = [string]$status.session.supervisorCreationTimeUtc
+                SessionId = $sessionId
+                UserSid = [string]$identity.User.Value
+            }
+        } finally {
+            if ($null -ne $identity) { $identity.Dispose() }
+        }
+    } catch {
+        return $null
+    }
+}
+
+function Test-CcodUpgradeProcessIdentity {
+    param([Parameter(Mandatory)]$Identity)
+    $process = Get-Process -Id $Identity.Pid -ErrorAction SilentlyContinue
+    if ($null -eq $process) { return $false }
+    try {
+        return $process.SessionId -eq $Identity.SessionId -and
+            $process.StartTime.ToUniversalTime().ToString('o', [Globalization.CultureInfo]::InvariantCulture) -ceq $Identity.CreationTimeUtc
+    } finally {
+        $process.Dispose()
+    }
+}
+
+$root = Get-CcodUpgradeCanonicalPath $InstallRoot
+$identity = Get-CcodVerifiedSupervisor $root
+if ($null -eq $identity) { exit 0 }
+
+$eventName = "Local\CodexControlOtherDevices.Shutdown.$($identity.UserSid).$($identity.SessionId)"
+$event = $null
+try {
+    $rights = [Security.AccessControl.EventWaitHandleRights]::Modify -bor [Security.AccessControl.EventWaitHandleRights]::Synchronize
+    $event = [Threading.EventWaitHandle]::OpenExisting($eventName, $rights)
+    [void]$event.Set()
+} catch {
+    throw 'CCOD_UPGRADE_SHUTDOWN_SIGNAL_FAILED'
+} finally {
+    if ($null -ne $event) { $event.Dispose() }
+}
+
+$deadline = [DateTime]::UtcNow.AddSeconds(10)
+while ([DateTime]::UtcNow -lt $deadline -and (Test-CcodUpgradeProcessIdentity $identity)) {
+    Start-Sleep -Milliseconds 200
+}
+if (Test-CcodUpgradeProcessIdentity $identity) {
+    Stop-Process -Id $identity.Pid -Force -ErrorAction Stop
+    $killDeadline = [DateTime]::UtcNow.AddSeconds(5)
+    while ([DateTime]::UtcNow -lt $killDeadline -and (Test-CcodUpgradeProcessIdentity $identity)) {
+        Start-Sleep -Milliseconds 200
+    }
+}
+if (Test-CcodUpgradeProcessIdentity $identity) { throw 'CCOD_UPGRADE_SUPERVISOR_STOP_FAILED' }
+exit 0

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.4.18-setup.exe` and `CodexRemote-fix-2.4.18-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.4.18-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.4.19-setup.exe` and `CodexRemote-fix-2.4.19-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.4.19-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. When the tray icon is green, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,12 @@ needed after upgrading.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.4.19
+
+- Added a native **About** menu item; it opens an information dialog with the active CodexRemote-fix version, such as `2.4.19`.
+- The installer now stops the verified running supervisor before replacing the installed runtime, while preserving device keys and persistent state.
+- The existing atomic runtime upgrade remains in place; old runtime files are retired only after the new runtime is activated successfully.
 
 ## What's new in v2.4.18
 
@@ -97,8 +103,8 @@ supervisor are working.
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.4.18 release includes the ready-to-run `CodexRemote-fix-2.4.18-setup.exe`
-and `CodexRemote-fix-2.4.18-setup.exe.sha256.txt`.
+so the 2.4.19 release includes the ready-to-run `CodexRemote-fix-2.4.19-setup.exe`
+and `CodexRemote-fix-2.4.19-setup.exe.sha256.txt`.
 
 Each release appends a short bilingual change summary to this README and to the GitHub release body.
 The full history is in [CHANGELOG.md](CHANGELOG.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.18-setup.exe` 和 `CodexRemote-fix-2.4.18-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.4.18-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.19-setup.exe` 和 `CodexRemote-fix-2.4.19-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.4.19-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。托盘图标为绿色时，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.4.19 更新内容
+
+- 新增原生 **关于** 菜单项，点击后显示当前 CodexRemote-fix 版本，例如 `2.4.19`。
+- 安装器会在替换已安装运行时前，先停止并验证当前守护程序，同时保留设备密钥和持久化状态。
+- 保留现有原子 runtime 升级流程，只有新运行时成功激活后才清理旧运行时文件。
 
 ## v2.4.18 更新内容
 
@@ -90,8 +96,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
 `.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此后续每次更新都会
-为 2.4.18 发布提供可直接运行的 `CodexRemote-fix-2.4.18-setup.exe`
-及 `CodexRemote-fix-2.4.18-setup.exe.sha256.txt`。
+为 2.4.19 发布提供可直接运行的 `CodexRemote-fix-2.4.19-setup.exe`
+及 `CodexRemote-fix-2.4.19-setup.exe.sha256.txt`。
 
 每次发布都会在本 README 和 GitHub Release 正文中追加简短的中英文更新说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/build/CodexControlOtherDevices.iss
+++ b/build/CodexControlOtherDevices.iss
@@ -25,7 +25,7 @@ SolidCompression=yes
 WizardStyle=modern
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
-CloseApplications=no
+CloseApplications=force
 RestartApplications=no
 SetupLogging=yes
 MinVersion=10.0.17763
@@ -60,6 +60,7 @@ Source: "..\Uninstall-CodexControlOtherDevices.ps1"; DestDir: "{app}"; Flags: ig
 Source: "..\Start-CodexControlOtherDevices.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\Reset-CodexControlOtherDevices.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\Test-CodexControlOtherDevices.ps1"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\Prepare-CcodRemoteUpgrade.ps1"; DestDir: "{tmp}"; Flags: dontcopy
 
 [InstallDelete]
 Type: files; Name: "{userprograms}\Codex Control other devices\Codex Control other devices for Windows.lnk"
@@ -93,6 +94,29 @@ end;
 function InitializeSetup(): Boolean;
 begin
   if IsAppInstalled() then
-    MsgBox('CodexRemote-fix is already installed. Run the new setup to upgrade the installed files, then the persistent supervisor will be updated.', mbInformation, MB_OK);
+    MsgBox('CodexRemote-fix is already installed. The current supervisor will be stopped safely before the new runtime replaces the old one; device keys and state are preserved.', mbInformation, MB_OK);
   Result := True;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: Integer;
+  ScriptPath: String;
+  Parameters: String;
+begin
+  Result := '';
+  NeedsRestart := False;
+  if not IsAppInstalled() then
+    Exit;
+  try
+    ExtractTemporaryFile('Prepare-CcodRemoteUpgrade.ps1');
+    ScriptPath := ExpandConstant('{tmp}\Prepare-CcodRemoteUpgrade.ps1');
+    Parameters := '-NoProfile -ExecutionPolicy Bypass -File "' + ScriptPath + '" -InstallRoot "' + ExpandConstant('{localappdata}\CodexControlOtherDevices') + '"';
+    if not Exec(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'), Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+      Result := 'Could not start the previous CodexRemote-fix shutdown helper.'
+    else if ResultCode <> 0 then
+      Result := 'The previous CodexRemote-fix supervisor could not be stopped safely.';
+  except
+    Result := 'The previous CodexRemote-fix supervisor could not be stopped safely.';
+  end;
 end;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/Supervisor.ps1
+++ b/src/persistence/Supervisor.ps1
@@ -20,7 +20,7 @@ $script:CcodSupervisorUiLanguageModes=@('System','zh-CN','en-US')
 $script:CcodSupervisorUiKeys=@(
     'Tray.Title','Status.Waiting','Status.Inspecting','Status.Transitioning','Status.Active','Status.ActivePaused','Status.Suppressed','Status.Recovered','Status.Error','Status.RendererHandoff',
     'Tooltip.Waiting','Tooltip.Inspecting','Tooltip.Transitioning','Tooltip.Active','Tooltip.ActivePaused','Tooltip.Suppressed','Tooltip.Recovered','Tooltip.Error',
-    'Menu.SessionReady','Menu.ApplyNow','Menu.ManualRetry','Menu.Automation','Menu.CandidateOptIn','Menu.Language','Menu.FollowSystem','Menu.Chinese','Menu.English','Menu.OpenLogs','Menu.Uninstall',
+    'Menu.SessionReady','Menu.ApplyNow','Menu.ManualRetry','Menu.Automation','Menu.CandidateOptIn','Menu.Language','Menu.FollowSystem','Menu.Chinese','Menu.English','Menu.OpenLogs','Menu.About','Menu.AboutVersion','Menu.Uninstall',
     'Dialog.UninstallTitle','Dialog.UninstallMessage','Error.UninstallStart','Error.LanguageChange'
 )
 $script:CcodSupervisorCleanupAllowlist=@(

--- a/src/persistence/modules/TrayHostClient.psm1
+++ b/src/persistence/modules/TrayHostClient.psm1
@@ -23,7 +23,7 @@ function Convert-CcodTrayHostState([string]$Value) {
 }
 
 function New-CcodTrayHostSnapshot {
-    param($Presentation,$Catalog,[string]$LanguageMode,[string]$SystemCultureName,[UInt64]$Revision)
+    param($Presentation,$Catalog,[string]$LanguageMode,[string]$SystemCultureName,[UInt64]$Revision,[string]$RuntimeId)
     $flags=[PresentationFlags]::None
     $flagMap=@{
         SessionReadyVisible=[PresentationFlags]::SessionReadyVisible;ApplyNowVisible=[PresentationFlags]::ApplyNowVisible;ApplyNowEnabled=[PresentationFlags]::ApplyNowEnabled
@@ -43,6 +43,9 @@ function New-CcodTrayHostSnapshot {
     $follow=Get-CcodUiString -Catalog $Catalog -Key 'Menu.FollowSystem' -Arguments @($systemLanguage)
     $tooltipKey='Tooltip.'+$stateKey
     $tooltip=if($null -ne $Catalog.Strings.PSObject.Properties[$tooltipKey]){$Catalog.Strings.$tooltipKey}else{$Catalog.Strings.'Tooltip.Waiting'}
+    $projectVersion='unknown'
+    if($RuntimeId -is [string] -and $RuntimeId -cmatch '^(?<version>\d+\.\d+\.\d+)-'){$projectVersion=$Matches['version']}
+    $aboutVersion=Get-CcodUiString -Catalog $Catalog -Key 'Menu.AboutVersion' -Arguments @($projectVersion)
     $strings=[string[]]@(
         $Catalog.Strings.'Tray.Title',
         $Catalog.Strings.('Status.'+$stateKey),
@@ -56,12 +59,14 @@ function New-CcodTrayHostSnapshot {
         $Catalog.Strings.'Menu.Chinese',
         $Catalog.Strings.'Menu.English',
         $Catalog.Strings.'Menu.OpenLogs',
+        $Catalog.Strings.'Menu.About',
         $Catalog.Strings.'Menu.Uninstall',
         $Catalog.Strings.'Error.UninstallStart',
         $Catalog.Strings.'Menu.Uninstall',
         $tooltip,
         $Catalog.Strings.'Dialog.UninstallTitle',
-        $Catalog.Strings.'Dialog.UninstallMessage'
+        $Catalog.Strings.'Dialog.UninstallMessage',
+        $aboutVersion
     )
     $mode=if($LanguageMode -ceq 'zh-CN'){[LanguageMode]::Chinese}elseif($LanguageMode -ceq 'en-US'){[LanguageMode]::English}else{[LanguageMode]::System}
     return [PresentationSnapshot]::new($Revision,(Convert-CcodTrayHostColor $Presentation.Color),(Convert-CcodTrayHostState $stateKey),$mode,$flags,$strings)
@@ -72,20 +77,20 @@ function New-CcodTrayHostContext {
     Import-CcodTrayHostAssembly
     $runtimeRoot=Get-CcodTrayHostRuntimeRoot;$runtimeId=Split-Path $runtimeRoot -Leaf;$exe=Join-Path $runtimeRoot 'bin\CodexRemote.TrayHost.exe'
     $initialPresentation=[pscustomobject][ordered]@{Color='Gray';StateKey='Waiting';SessionReadyVisible=$false;ApplyNowVisible=$false;ApplyNowEnabled=$false;ManualRetryVisible=$false;ManualRetryEnabled=$false;AutomationToggleEnabled=$true;AutomationChecked=$false;CandidateOptInToggleEnabled=$true;CandidateOptInChecked=$false;OpenLogsEnabled=$true;UninstallEnabled=$true;Busy=$false}
-    $initial=New-CcodTrayHostSnapshot $initialPresentation $Catalog $LanguageMode $SystemCultureName ([UInt64]1)
+    $initial=New-CcodTrayHostSnapshot $initialPresentation $Catalog $LanguageMode $SystemCultureName ([UInt64]1) $runtimeId
     $process=[Diagnostics.Process]::GetCurrentProcess()
     try{
         $options=[TrayHostStartOptions]::new();$options.ExePath=$exe;$options.RuntimeId=$runtimeId;$options.ParentPid=$process.Id;$options.ParentCreationFileTimeUtc=$process.StartTime.ToFileTimeUtc();$options.InitialPresentation=$initial
         $client=[TrayHostParentClient]::Start($options)
     }finally{$process.Dispose()}
-    return [pscustomobject][ordered]@{Client=$client;CommandQueue=$CommandQueue;OnTick=$OnTick;Catalog=$Catalog;LanguageMode=$LanguageMode;SystemCultureName=$SystemCultureName;CurrentRevision=[UInt64]1;MenuOpen=$false;Exited=$false;LastError=$null;ApplicationContext=[pscustomobject]@{}}
+    return [pscustomobject][ordered]@{Client=$client;CommandQueue=$CommandQueue;OnTick=$OnTick;Catalog=$Catalog;LanguageMode=$LanguageMode;SystemCultureName=$SystemCultureName;RuntimeId=$runtimeId;CurrentRevision=[UInt64]1;MenuOpen=$false;Exited=$false;LastError=$null;ApplicationContext=[pscustomobject]@{}}
 }
 
 function Set-CcodTrayHostPresentation {
     param($Context,$Presentation,$Catalog,[string]$LanguageMode,[string]$SystemCultureName)
     if($null -eq $Context -or $null -eq $Context.Client){throw 'CCOD_TRAYHOST_CONTEXT_INVALID'}
     $revision=[UInt64]([UInt64]$Context.CurrentRevision + [UInt64]1)
-    $snapshot=New-CcodTrayHostSnapshot $Presentation $Catalog $LanguageMode $SystemCultureName $revision
+    $snapshot=New-CcodTrayHostSnapshot $Presentation $Catalog $LanguageMode $SystemCultureName $revision $Context.RuntimeId
     if(-not $Context.Client.TryPublish($snapshot)){throw 'CCOD_TRAYHOST_PRESENTATION_FAILED'}
     $Context.Catalog=$Catalog;$Context.LanguageMode=$LanguageMode;$Context.SystemCultureName=$SystemCultureName;$Context.CurrentRevision=$revision
 }

--- a/src/persistence/modules/TrayUi.psm1
+++ b/src/persistence/modules/TrayUi.psm1
@@ -16,7 +16,7 @@ $script:TrayUiLanguageModes=@('System','zh-CN','en-US')
 $script:TrayUiCatalogKeys=@(
     'Tray.Title','Status.Waiting','Status.Inspecting','Status.Transitioning','Status.Active','Status.ActivePaused','Status.Suppressed','Status.Recovered','Status.Error','Status.RendererHandoff',
     'Tooltip.Waiting','Tooltip.Inspecting','Tooltip.Transitioning','Tooltip.Active','Tooltip.ActivePaused','Tooltip.Suppressed','Tooltip.Recovered','Tooltip.Error',
-    'Menu.SessionReady','Menu.ApplyNow','Menu.ManualRetry','Menu.Automation','Menu.CandidateOptIn','Menu.Language','Menu.FollowSystem','Menu.Chinese','Menu.English','Menu.OpenLogs','Menu.Uninstall',
+    'Menu.SessionReady','Menu.ApplyNow','Menu.ManualRetry','Menu.Automation','Menu.CandidateOptIn','Menu.Language','Menu.FollowSystem','Menu.Chinese','Menu.English','Menu.OpenLogs','Menu.About','Menu.AboutVersion','Menu.Uninstall',
     'Dialog.UninstallTitle','Dialog.UninstallMessage','Error.UninstallStart','Error.LanguageChange'
 )
 $script:TrayCleanupCodeAllowlist=@(

--- a/src/persistence/modules/UiLocalization.psm1
+++ b/src/persistence/modules/UiLocalization.psm1
@@ -4,7 +4,7 @@ $script:CcodUiModes=@('System','zh-CN','en-US')
 $script:CcodUiKeys=@(
   'Tray.Title','Status.Waiting','Status.Inspecting','Status.Transitioning','Status.Active','Status.ActivePaused','Status.Suppressed','Status.Recovered','Status.Error','Status.RendererHandoff',
   'Tooltip.Waiting','Tooltip.Inspecting','Tooltip.Transitioning','Tooltip.Active','Tooltip.ActivePaused','Tooltip.Suppressed','Tooltip.Recovered','Tooltip.Error',
-  'Menu.SessionReady','Menu.ApplyNow','Menu.ManualRetry','Menu.Automation','Menu.CandidateOptIn','Menu.Language','Menu.FollowSystem','Menu.Chinese','Menu.English','Menu.OpenLogs','Menu.Uninstall',
+  'Menu.SessionReady','Menu.ApplyNow','Menu.ManualRetry','Menu.Automation','Menu.CandidateOptIn','Menu.Language','Menu.FollowSystem','Menu.Chinese','Menu.English','Menu.OpenLogs','Menu.About','Menu.AboutVersion','Menu.Uninstall',
   'Dialog.UninstallTitle','Dialog.UninstallMessage','Error.UninstallStart','Error.LanguageChange'
 )
 $script:CcodUiEmergencyEnglish=[ordered]@{
@@ -36,6 +36,8 @@ $script:CcodUiEmergencyEnglish=[ordered]@{
   'Menu.Chinese'=([char]0x4e2d+[char]0x6587)
   'Menu.English'='English'
   'Menu.OpenLogs'='Open logs'
+  'Menu.About'='About'
+  'Menu.AboutVersion'='CodexRemote-fix | Version {0}'
   'Menu.Uninstall'=('Uninstall supervisor'+[char]0x2026)
   'Dialog.UninstallTitle'='Uninstall Codex connection supervisor?'
   'Dialog.UninstallMessage'='This stops the supervisor. A managed Codex session will restart normally. Device keys are kept by default.'

--- a/src/persistence/resources/ui.en-US.json
+++ b/src/persistence/resources/ui.en-US.json
@@ -30,6 +30,8 @@
     "Menu.Chinese": "\u4e2d\u6587",
     "Menu.English": "English",
     "Menu.OpenLogs": "Open logs",
+    "Menu.About": "About",
+    "Menu.AboutVersion": "CodexRemote-fix | Version {0}",
     "Menu.Uninstall": "Uninstall supervisor\u2026",
     "Dialog.UninstallTitle": "Uninstall Codex connection supervisor?",
     "Dialog.UninstallMessage": "This stops the supervisor. A managed Codex session will restart normally. Device keys are kept by default.",

--- a/src/persistence/resources/ui.zh-CN.json
+++ b/src/persistence/resources/ui.zh-CN.json
@@ -30,6 +30,8 @@
     "Menu.Chinese": "\u4e2d\u6587",
     "Menu.English": "English",
     "Menu.OpenLogs": "\u6253\u5f00\u65e5\u5fd7",
+    "Menu.About": "\u5173\u4e8e",
+    "Menu.AboutVersion": "CodexRemote-fix \uff5c \u7248\u672c {0}",
     "Menu.Uninstall": "\u5378\u8f7d\u5b88\u62a4\u7a0b\u5e8f\u2026",
     "Dialog.UninstallTitle": "\u5378\u8f7d Codex \u8fde\u63a5\u5b88\u62a4\u7a0b\u5e8f\uff1f",
     "Dialog.UninstallMessage": "\u8fd9\u5c06\u505c\u6b62\u5b88\u62a4\u7a0b\u5e8f\u3002\u5982\u679c\u5f53\u524d Codex \u4f1a\u8bdd\u5df2\u63a5\u7ba1\uff0cCodex \u5c06\u6062\u590d\u4e3a\u666e\u901a\u542f\u52a8\u3002\u9ed8\u8ba4\u4fdd\u7559\u8bbe\u5907\u5bc6\u94a5\u3002",

--- a/src/trayhost/AssemblyInfo.cs
+++ b/src/trayhost/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Persistent native tray host for CodexRemote-fix")]
 [assembly: AssemblyCompany("CodexRemote-fix contributors")]
 [assembly: AssemblyProduct("CodexRemote-fix")]
-[assembly: AssemblyVersion("2.4.18.0")]
-[assembly: AssemblyFileVersion("2.4.18.0")]
+[assembly: AssemblyVersion("2.4.19.0")]
+[assembly: AssemblyFileVersion("2.4.19.0")]
 [assembly: ComVisible(false)]

--- a/src/trayhost/CodexRemote.TrayHost.manifest
+++ b/src/trayhost/CodexRemote.TrayHost.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.4.18.0" name="CodexRemote.fix.TrayHost" type="win32" />
+  <assemblyIdentity version="2.4.19.0" name="CodexRemote.fix.TrayHost" type="win32" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/trayhost/NativeMenu.cs
+++ b/src/trayhost/NativeMenu.cs
@@ -70,12 +70,13 @@ internal sealed class NativeMenu : IDisposable
             Append(language, TrayNativeConstants.MfString | LanguageChecked(LanguageMode.English), (uint)TrayCommand.SetLanguageEnglish, 10);
 
             Append(_menu, TrayNativeConstants.MfString | Enabled(11), (uint)TrayCommand.OpenLogs, 11);
+            Append(_menu, TrayNativeConstants.MfString, (uint)TrayCommand.ShowAbout, 12);
             IntPtr uninstall = _native.CreateSubMenu();
             if (uninstall == IntPtr.Zero) { throw new InvalidOperationException("CreateUninstallMenu failed"); }
-            if (!_native.AppendSubMenu(_menu, uninstall, _snapshot.Strings[12])) { throw new InvalidOperationException("AppendUninstallMenu failed"); }
-            Append(uninstall, TrayNativeConstants.MfString | TrayNativeConstants.MfDisabled | TrayNativeConstants.MfGrayed, 0U, 13);
-            Append(uninstall, TrayNativeConstants.MfString | (Has(PresentationFlags.UninstallEnabled) ? 0U : TrayNativeConstants.MfDisabled | TrayNativeConstants.MfGrayed), (uint)TrayCommand.ConfirmUninstall, 14);
-            Append(_menu, TrayNativeConstants.MfString | TrayNativeConstants.MfDisabled | TrayNativeConstants.MfGrayed, 0U, 15);
+            if (!_native.AppendSubMenu(_menu, uninstall, _snapshot.Strings[13])) { throw new InvalidOperationException("AppendUninstallMenu failed"); }
+            Append(uninstall, TrayNativeConstants.MfString | TrayNativeConstants.MfDisabled | TrayNativeConstants.MfGrayed, 0U, 14);
+            Append(uninstall, TrayNativeConstants.MfString | (Has(PresentationFlags.UninstallEnabled) ? 0U : TrayNativeConstants.MfDisabled | TrayNativeConstants.MfGrayed), (uint)TrayCommand.ConfirmUninstall, 15);
+            Append(_menu, TrayNativeConstants.MfString | TrayNativeConstants.MfDisabled | TrayNativeConstants.MfGrayed, 0U, 16);
         }
         catch
         {

--- a/src/trayhost/NativeMethods.cs
+++ b/src/trayhost/NativeMethods.cs
@@ -35,6 +35,8 @@ internal static class TrayNativeConstants
     internal const int IdiApplication = 32512;
     internal const uint ImageIcon = 1;
     internal const uint LrDefaultSize = 0x00000040;
+    internal const uint MbOk = 0x00000000;
+    internal const uint MbIconInformation = 0x00000040;
 }
 
 [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -91,6 +93,7 @@ internal interface INativeTrayPlatform
     uint TrackPopupMenuEx(IntPtr menu, uint flags, int x, int y, IntPtr owner, IntPtr parameters);
     bool PostMessage(IntPtr owner, uint message, UIntPtr wParam, IntPtr lParam);
     bool SetNotificationFocus(ref TrayIconData icon);
+    bool ShowMessageBox(IntPtr owner, string text, string caption);
     bool DestroyMenu(IntPtr menu);
     bool EndMenu();
     bool DestroyOwner(IntPtr owner);
@@ -151,6 +154,7 @@ internal sealed class Win32TrayPlatform : INativeTrayPlatform
     }
     public bool DeleteIcon(ref TrayIconData icon) { return Shell_NotifyIconW(TrayNativeConstants.NimDelete, ref icon); }
     public bool SetNotificationFocus(ref TrayIconData icon) { return Shell_NotifyIconW(TrayNativeConstants.NimSetFocus, ref icon); }
+    public bool ShowMessageBox(IntPtr owner, string text, string caption) { return MessageBoxW(owner, text ?? String.Empty, caption ?? String.Empty, TrayNativeConstants.MbOk | TrayNativeConstants.MbIconInformation) != 0; }
 
     public IntPtr CreatePopupMenu() { return CreatePopupMenuNative(); }
     public IntPtr CreateSubMenu() { return CreatePopupMenuNative(); }
@@ -268,5 +272,6 @@ internal sealed class Win32TrayPlatform : INativeTrayPlatform
     [DllImport("user32.dll", SetLastError = true)] [return: MarshalAs(UnmanagedType.Bool)] private static extern bool PostMessageW(IntPtr window, uint message, UIntPtr wParam, IntPtr lParam);
     [DllImport("user32.dll", EntryPoint = "DestroyMenu", SetLastError = true)] [return: MarshalAs(UnmanagedType.Bool)] private static extern bool DestroyMenuNative(IntPtr menu);
     [DllImport("user32.dll", EntryPoint = "EndMenu", SetLastError = true)] [return: MarshalAs(UnmanagedType.Bool)] private static extern bool EndMenuNative();
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)] private static extern int MessageBoxW(IntPtr owner, string text, string caption, uint type);
     [DllImport("user32.dll", SetLastError = true)] [return: MarshalAs(UnmanagedType.Bool)] private static extern bool DestroyWindow(IntPtr window);
 }

--- a/src/trayhost/PipeProtocol.cs
+++ b/src/trayhost/PipeProtocol.cs
@@ -36,7 +36,8 @@ public enum TrayCommand : ushort
     SetLanguageChinese = 1006,
     SetLanguageEnglish = 1007,
     OpenLogs = 1008,
-    ConfirmUninstall = 1009
+    ConfirmUninstall = 1009,
+    ShowAbout = 1010
 }
 
 internal sealed class ProtocolViolationException : IOException

--- a/src/trayhost/PresentationSnapshot.cs
+++ b/src/trayhost/PresentationSnapshot.cs
@@ -37,7 +37,7 @@ public sealed class PresentationSnapshot
         if (revision == 0UL) { throw new ArgumentException("revision must be positive", "revision"); }
         if (!Enum.IsDefined(typeof(TrayColor), color) || !Enum.IsDefined(typeof(TrayState), state) || !Enum.IsDefined(typeof(LanguageMode), language)) { throw new ArgumentException("presentation enum is invalid"); }
         if ((((uint)flags) & ~0x00000fffu) != 0u) { throw new ArgumentException("presentation flags are invalid", "flags"); }
-        if (strings == null || strings.Length != 18) { throw new ArgumentException("presentation string count is invalid", "strings"); }
+        if (strings == null || strings.Length != 20) { throw new ArgumentException("presentation string count is invalid", "strings"); }
         string[] copy = (string[])strings.Clone();
         for (int i = 0; i < copy.Length; i++)
         {

--- a/src/trayhost/Program.cs
+++ b/src/trayhost/Program.cs
@@ -103,7 +103,7 @@ internal static class Program
 
     private static int RunHeadlessSmoke()
     {
-        string[] strings = new string[18]; for (int i = 0; i < strings.Length; i++) { strings[i] = "smoke-" + i; }
+        string[] strings = new string[20]; for (int i = 0; i < strings.Length; i++) { strings[i] = "smoke-" + i; }
         PresentationSnapshot snapshot = new PresentationSnapshot(1UL, TrayColor.Green, TrayState.Active, LanguageMode.Chinese, PresentationFlags.OpenLogsEnabled, strings);
         byte[] seed = new byte[32]; byte[] challenge = new byte[32]; byte[] nonce = new byte[32];
         SessionKeys keys = ProtocolCodec.DeriveDirectionalKeys(seed, challenge, nonce, 1UL);

--- a/src/trayhost/TrayHostWire.cs
+++ b/src/trayhost/TrayHostWire.cs
@@ -99,7 +99,7 @@ internal static class TrayHostWire
         using (BinaryReader reader = new BinaryReader(stream, Utf8))
         {
             ulong revision = reader.ReadUInt64(); TrayColor color = (TrayColor)reader.ReadByte(); TrayState state = (TrayState)reader.ReadByte(); LanguageMode language = (LanguageMode)reader.ReadByte(); PresentationFlags flags = (PresentationFlags)reader.ReadUInt32(); int count = reader.ReadByte();
-            if (count != 18) { throw new ProtocolViolationException("presentation string count is invalid"); }
+            if (count != 20) { throw new ProtocolViolationException("presentation string count is invalid"); }
             string[] strings = new string[count]; for (int i = 0; i < count; i++) { strings[i] = ReadString(reader, 300); }
             RequireEnd(stream);
             try { return new PresentationSnapshot(revision, color, state, language, flags, strings); } catch (ArgumentException error) { throw new ProtocolViolationException(error.Message); }

--- a/src/trayhost/TrayWindow.cs
+++ b/src/trayhost/TrayWindow.cs
@@ -67,7 +67,11 @@ internal sealed class TrayWindow : IDisposable
         {
             _inputGuard.VerifyNoOwnerInputContext(_owner);
             using (NativeMenu menu = new NativeMenu(_native, _owner, _current)) { result = menu.Show(point); }
-            if (result != 0U && Enum.IsDefined(typeof(TrayCommand), (ushort)result) && (TrayCommand)result != TrayCommand.None)
+            if (result == (uint)TrayCommand.ShowAbout)
+            {
+                _native.ShowMessageBox(_owner, _current.Strings[19], _current.Strings[12]);
+            }
+            else if (result != 0U && Enum.IsDefined(typeof(TrayCommand), (ushort)result) && (TrayCommand)result != TrayCommand.None)
             {
                 Action<TrayCommand, ulong> handler = CommandSelected;
                 if (handler != null) { handler((TrayCommand)result, _current.Revision); }

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1112,19 +1112,38 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.18 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.19 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.4.18' ([string]$package.version) 'package version is exactly 2.4.18'
+    Assert-CcodEqual '2.4.19' ([string]$package.version) 'package version is exactly 2.4.19'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.4.18-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.19-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.4.18-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.19-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+}
+
+$results += Invoke-CcodTest 'installer stops the running supervisor before replacing the installed version' {
+    $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw -Encoding UTF8
+    $prepareScript = Join-Path $repositoryRoot 'Prepare-CcodRemoteUpgrade.ps1'
+    Assert-CcodTrue (Test-Path -LiteralPath $prepareScript -PathType Leaf) 'pre-upgrade supervisor stopper exists'
+    Assert-CcodTrue ($installerScript -cmatch '(?m)^CloseApplications=force\r?$') 'installer requests forced application closure'
+    Assert-CcodTrue ($installerScript -cmatch '(?m)^function PrepareToInstall\(') 'installer runs the pre-upgrade hook'
+    Assert-CcodTrue ($installerScript -cmatch 'Prepare-CcodRemoteUpgrade\.ps1') 'installer bundles and invokes the pre-upgrade supervisor stopper'
+}
+
+$results += Invoke-CcodTest 'pre-upgrade supervisor stopper exits cleanly when no old runtime is present' {
+    $root = Join-Path ([IO.Path]::GetTempPath()) ('ccod-upgrade-no-old-' + [guid]::NewGuid().ToString('N'))
+    try {
+        $output = @(& (Join-Path $repositoryRoot 'Prepare-CcodRemoteUpgrade.ps1') -InstallRoot $root 2>&1)
+        Assert-CcodEqual 0 $LASTEXITCODE 'pre-upgrade helper no-op exits successfully without an installed supervisor'
+    } finally {
+        if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
 }
 
 $results += Invoke-CcodTest 'CodexRemote-fix icon is a bounded multi-resolution PNG ICO' {
@@ -1208,16 +1227,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.18-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.18-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.18-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.18-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/TrayHostBuild.SelfTest.ps1
+++ b/tests/persistence/TrayHostBuild.SelfTest.ps1
@@ -38,12 +38,12 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
     Import-Module $modulePath -Force
     $artifact=Join-Path $env:TEMP ('ccod-trayhost-artifact-'+[Guid]::NewGuid().ToString('N'))
     try{
-        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.4.18' -OutputDirectory $artifact
+        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.4.19' -OutputDirectory $artifact
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe') -PathType Leaf) 'TrayHost executable exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe.config') -PathType Leaf) 'TrayHost config exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -PathType Leaf) 'TrayHost provenance exists'
         $provenance=Get-Content -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -Raw|ConvertFrom-Json
-        Assert-CcodEqual '2.4.18' ([string]$provenance.version) 'provenance version is exact'
+        Assert-CcodEqual '2.4.19' ([string]$provenance.version) 'provenance version is exact'
         $icon=Join-Path $repositoryRoot 'assets\codexremote-fix\codexremote-fix.ico'
         Assert-CcodTrue (Test-Path -LiteralPath $icon -PathType Leaf) 'TrayHost product ICO exists'
         $iconSha=[Security.Cryptography.SHA256]::Create();try{$iconHash=([BitConverter]::ToString($iconSha.ComputeHash([IO.File]::ReadAllBytes($icon)))).Replace('-','').ToLowerInvariant()}finally{$iconSha.Dispose()}
@@ -51,7 +51,7 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
         Assert-CcodTrue (@($provenance.sourceFiles).Count -ge 10) 'provenance includes every TrayHost source'
         Assert-CcodTrue (-not ([string]$provenance|Select-String -Pattern '[A-Za-z]:\\|\\\\' -Quiet)) 'provenance does not leak absolute paths'
         $tampered=Join-Path $artifact 'CodexRemote.TrayHost.exe.config'; Add-Content -LiteralPath $tampered -Value 'x'
-        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.4.18' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
+        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.4.19' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
         Assert-CcodTrue $threw 'tampered artifact is rejected'
     }finally{if(Test-Path -LiteralPath $artifact){Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue}}
 }

--- a/tests/persistence/TrayHostClient.SelfTest.ps1
+++ b/tests/persistence/TrayHostClient.SelfTest.ps1
@@ -16,4 +16,12 @@ Invoke-CcodTest 'Supervisor imports the TrayHost client as its only production t
     Assert-CcodTrue ($supervisor -match 'Invoke-CcodTrayHostRunLoop') 'default RunUiContext delegates to TrayHostClient'
 }
 
+Invoke-CcodTest 'TrayHost client carries the localized About item and active runtime version contract' {
+    $source = Get-Content -LiteralPath $modulePath -Raw -Encoding UTF8
+    Assert-CcodTrue ($source -cmatch "Menu\.AboutVersion") 'snapshot formats the localized About version string'
+    Assert-CcodTrue ($source -cmatch "RuntimeId -is \[string\].*\^\(\?<version\>\\d\+\\\.\\d\+\\\.\\d\+\)-") 'snapshot extracts the semantic version from the active runtime id'
+    Assert-CcodTrue ($source -cmatch "Menu\.About',") 'snapshot carries the localized About menu label'
+    Assert-CcodTrue ($source -cmatch '\$aboutVersion') 'snapshot appends the About message to the presentation payload'
+}
+
 Write-Host 'TrayHost client self-tests passed.'

--- a/tests/trayhost/TrayHostNativeSelfTest.cs
+++ b/tests/trayhost/TrayHostNativeSelfTest.cs
@@ -12,6 +12,7 @@ internal sealed class FakeTrayPlatform : INativeTrayPlatform
     internal bool SawNonzeroIcon;
     internal Action DuringTrack;
     internal int TrackCalls;
+    internal readonly List<string> MessageBoxes = new List<string>();
 
     public IntPtr CreateOwner() { Calls.Add("CreateOwner"); return new IntPtr(10); }
     public IntPtr AssociateOwnerInputContext(IntPtr owner, IntPtr context) { Calls.Add(context == IntPtr.Zero ? "Associate:null" : "Associate:restore"); return new IntPtr(20); }
@@ -33,6 +34,7 @@ internal sealed class FakeTrayPlatform : INativeTrayPlatform
     public uint TrackPopupMenuEx(IntPtr menu, uint flags, int x, int y, IntPtr owner, IntPtr parameters) { Calls.Add("Track"); TrackCalls++; if (DuringTrack != null) { DuringTrack(); } return TrackResult; }
     public bool PostMessage(IntPtr owner, uint message, UIntPtr wParam, IntPtr lParam) { Calls.Add("WM_NULL"); return true; }
     public bool SetNotificationFocus(ref TrayIconData icon) { Calls.Add("NIM_SETFOCUS"); return true; }
+    public bool ShowMessageBox(IntPtr owner, string text, string caption) { MessageBoxes.Add(caption + "|" + text); Calls.Add("MessageBox"); return true; }
     public bool DestroyMenu(IntPtr menu) { Calls.Add("DestroyMenu"); return true; }
     public bool EndMenu() { Calls.Add("EndMenu"); return true; }
     public bool DestroyOwner(IntPtr owner) { Calls.Add("DestroyOwner"); return true; }
@@ -45,7 +47,7 @@ internal static class TrayHostNativeSelfTest
 
     private static PresentationSnapshot Snapshot(ulong revision)
     {
-        string[] strings = new string[18];
+        string[] strings = new string[20];
         for (int i = 0; i < strings.Length; i++) { strings[i] = "s" + i; }
         return new PresentationSnapshot(revision, TrayColor.Green, TrayState.Active, LanguageMode.Chinese,
             PresentationFlags.SessionReadyVisible | PresentationFlags.ApplyNowVisible | PresentationFlags.ApplyNowEnabled |
@@ -67,7 +69,7 @@ internal static class TrayHostNativeSelfTest
         platform.TrackResult = 0;
         AssertTrue(window.HandleContextMenu(new TrayPoint(10, 20)) == 0, "cancel returns zero");
         AssertTrue(platform.SawNonzeroIcon, "NIM_ADD receives a valid HICON");
-        AssertEqual("CreateOwner|Associate:null|GetContext|LoadIcon|NIM_ADD|NIM_SETVERSION|GetContext|GetContext|CreateMenu|Append:s0|Append:s1|Append:s2|Append:s3|Append:s4|Append:s5|Append:s6|SubMenu:s7|Append:s8|Append:s9|Append:s10|Append:s11|SubMenu:s12|Append:s13|Append:s14|Append:s15|ShowOwner|SetForeground|GetForeground|Track|WM_NULL|NIM_SETFOCUS|HideOwner|DestroyMenu", String.Join("|", platform.Calls.ToArray()), "native menu order is exact");
+        AssertEqual("CreateOwner|Associate:null|GetContext|LoadIcon|NIM_ADD|NIM_SETVERSION|GetContext|GetContext|CreateMenu|Append:s0|Append:s1|Append:s2|Append:s3|Append:s4|Append:s5|Append:s6|SubMenu:s7|Append:s8|Append:s9|Append:s10|Append:s11|Append:s12|SubMenu:s13|Append:s14|Append:s15|Append:s16|ShowOwner|SetForeground|GetForeground|Track|WM_NULL|NIM_SETFOCUS|HideOwner|DestroyMenu", String.Join("|", platform.Calls.ToArray()), "native menu order is exact");
         window.Dispose();
     }
 
@@ -114,6 +116,17 @@ internal static class TrayHostNativeSelfTest
         platform.Calls.Clear();
         window.ReAddAfterTaskbarCreated();
         AssertEqual("NIM_ADD|NIM_SETVERSION", String.Join("|", platform.Calls.ToArray()), "Explorer restore re-adds and versions the icon");
+        window.Dispose();
+    }
+
+    private static void TestAboutCommandShowsCurrentVersion()
+    {
+        FakeTrayPlatform platform = new FakeTrayPlatform();
+        TrayWindow window = NewWindow(platform);
+        platform.TrackResult = (uint)TrayCommand.ShowAbout;
+        window.HandleContextMenu(new TrayPoint(0, 0));
+        AssertTrue(platform.MessageBoxes.Count == 1, "about command shows one information box");
+        AssertEqual("s12|s19", platform.MessageBoxes[0], "about uses the localized caption and runtime version text");
         window.Dispose();
     }
 
@@ -169,6 +182,7 @@ internal static class TrayHostNativeSelfTest
             TestOwnerShowFailureNeverTracks();
             TestReentryAndPendingSnapshot();
             TestSelectedCommandAndTaskbarRestore();
+            TestAboutCommandShowsCurrentVersion();
             TestNoHimcFailureIsSafe();
             TestShellRightClickNotificationMapping();
             TestRealNativePInvokeSurface();

--- a/tests/trayhost/TrayHostParentClientSelfTest.cs
+++ b/tests/trayhost/TrayHostParentClientSelfTest.cs
@@ -10,7 +10,7 @@ internal static class TrayHostParentClientSelfTest
 
     private static PresentationSnapshot Snapshot(ulong revision)
     {
-        string[] strings = new string[18];
+        string[] strings = new string[20];
         for (int i = 0; i < strings.Length; i++) { strings[i] = "string-" + i; }
         return new PresentationSnapshot(revision, TrayColor.Green, TrayState.Active, LanguageMode.Chinese, PresentationFlags.OpenLogsEnabled, strings);
     }

--- a/tests/trayhost/TrayHostProtocolSelfTest.cs
+++ b/tests/trayhost/TrayHostProtocolSelfTest.cs
@@ -104,7 +104,7 @@ internal static class TrayHostProtocolSelfTest
 
     private static string[] ValidStrings()
     {
-        string[] values = new string[18];
+        string[] values = new string[20];
         for (int i = 0; i < values.Length; i++) { values[i] = "string-" + i; }
         return values;
     }
@@ -118,7 +118,7 @@ internal static class TrayHostProtocolSelfTest
             LanguageMode.Chinese,
             PresentationFlags.AutomationToggleEnabled | PresentationFlags.AutomationChecked,
             ValidStrings());
-        AssertTrue(snapshot.Revision == 1UL && snapshot.Strings.Count == 18, "presentation snapshot retains its validated fields");
+        AssertTrue(snapshot.Revision == 1UL && snapshot.Strings.Count == 20, "presentation snapshot retains its validated fields");
         bool threw = false;
         string[] invalid = ValidStrings();
         invalid[3] = "bad\rtext";

--- a/tests/trayhost/TrayHostTransportSelfTest.cs
+++ b/tests/trayhost/TrayHostTransportSelfTest.cs
@@ -10,7 +10,7 @@ internal static class TrayHostTransportSelfTest
 
     private static PresentationSnapshot Snapshot(ulong revision)
     {
-        string[] strings = new string[18];
+        string[] strings = new string[20];
         for (int i = 0; i < strings.Length; i++) { strings[i] = "string-" + i; }
         return new PresentationSnapshot(revision, TrayColor.Green, TrayState.Active, LanguageMode.Chinese, PresentationFlags.OpenLogsEnabled, strings);
     }


### PR DESCRIPTION
Adds the bilingual native About menu item with the active runtime version, and makes the installer stop/verify the existing supervisor before replacing the runtime. Device keys and persistent state remain preserved through the atomic upgrade. Includes regression tests and v2.4.19 release metadata.