### PR TITLE
release: CodexRemote-fix v2.4.20 deferred Codex restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This file keeps the short bilingual summary for every published release.
 
 No unreleased changes.
 
+## v2.4.20
+
+### English
+
+- Added a bilingual post-install prompt: restart Codex now or restart it manually later.
+- The installer never closes or restarts Codex automatically; **Later** leaves the current session untouched.
+- **Restart now** invokes the existing safe SessionController path only after explicit confirmation.
+
+### 简体中文
+
+- 安装完成后新增双语提示，可选择立即重启 Codex 或稍后手动重启。
+- 安装器不会自动关闭或重启 Codex；选择“稍后”会保持当前会话不受影响。
+- 只有明确选择“立即重启”后，才调用现有安全 SessionController 流程。
+
 ## v2.4.19
 
 ### English

--- a/Prompt-CcodRestart.ps1
+++ b/Prompt-CcodRestart.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$AppRoot,
+    [string]$InstallRoot,
+    [ValidateSet('Restart','Later')][string]$Choice
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-CcodPromptLanguage {
+    param([string]$Root)
+    try {
+        if (-not [string]::IsNullOrWhiteSpace($Root)) {
+            $preferencePath = Join-Path $Root 'state\ui-preferences.json'
+            if ([IO.File]::Exists($preferencePath)) {
+                $preference = Get-Content -LiteralPath $preferencePath -Raw | ConvertFrom-Json -ErrorAction Stop
+                if ($preference.LanguageMode -eq 'zh-CN') { return 'zh-CN' }
+                if ($preference.LanguageMode -eq 'en-US') { return 'en-US' }
+            }
+        }
+    } catch { }
+    if ([Globalization.CultureInfo]::CurrentUICulture.Name -match '^zh(?:-|$)') { return 'zh-CN' }
+    return 'en-US'
+}
+
+function Show-CcodRestartPrompt {
+    param([string]$Language)
+    Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
+    if ($Language -eq 'zh-CN') {
+        $localized = ('{"title":"CodexRemote-fix","message":"\\u9700\\u8981\\u91cd\\u542f Codex \\u624d\\u80fd\\u751f\\u6548\\u3002\\r\\n\\r\\n\\u7acb\\u5373\\u91cd\\u542f Codex \\u5417\\uff1f\\r\\n\\u9009\\u62e9 Yes \\u7acb\\u5373\\u91cd\\u542f\\uff0c\\u9009\\u62e9 No \\u7a0d\\u540e\\u624b\\u52a8\\u91cd\\u542f\\u3002"}' | ConvertFrom-Json)
+        $title = [string]$localized.title
+        $message = [string]$localized.message
+    } else {
+        $title = 'CodexRemote-fix'
+        $message = "Codex must be restarted for the fix to take effect.`r`n`r`nRestart Codex now?`r`nChoose Yes to restart now, or No to restart it manually later."
+    }
+    $result = [Windows.Forms.MessageBox]::Show(
+        $message,
+        $title,
+        [Windows.Forms.MessageBoxButtons]::YesNo,
+        [Windows.Forms.MessageBoxIcon]::Information,
+        [Windows.Forms.MessageBoxDefaultButton]::Button2
+    )
+    if ($result -eq [Windows.Forms.DialogResult]::Yes) { return 'Restart' }
+    return 'Later'
+}
+
+$selected = if ([string]::IsNullOrWhiteSpace($Choice)) { Show-CcodRestartPrompt -Language (Resolve-CcodPromptLanguage -Root $InstallRoot) } else { $Choice }
+if ($selected -ceq 'Later') { exit 0 }
+
+$startScript = [IO.Path]::GetFullPath((Join-Path $AppRoot 'Start-CodexControlOtherDevices.ps1'))
+if (-not [IO.File]::Exists($startScript)) { exit 1 }
+$powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
+$arguments = @('-NoProfile','-ExecutionPolicy','Bypass','-File',$startScript)
+$null = & $powershell @arguments 2>$null
+if ($LASTEXITCODE -ne 0) { exit 1 }
+exit 0

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.4.19-setup.exe` and `CodexRemote-fix-2.4.19-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.4.19-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.4.20-setup.exe` and `CodexRemote-fix-2.4.20-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.4.20-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. When the tray icon is green, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,12 @@ needed after upgrading.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.4.20
+
+- After installation, show a bilingual prompt: restart Codex now or restart it manually later.
+- The installer never closes or restarts Codex automatically; choosing **Later** leaves the current session untouched.
+- Choosing **Restart now** invokes the existing safe SessionController path only after explicit user confirmation.
 
 ## What's new in v2.4.19
 
@@ -103,8 +109,8 @@ supervisor are working.
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.4.19 release includes the ready-to-run `CodexRemote-fix-2.4.19-setup.exe`
-and `CodexRemote-fix-2.4.19-setup.exe.sha256.txt`.
+so the 2.4.20 release includes the ready-to-run `CodexRemote-fix-2.4.20-setup.exe`
+and `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`.
 
 Each release appends a short bilingual change summary to this README and to the GitHub release body.
 The full history is in [CHANGELOG.md](CHANGELOG.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.19-setup.exe` 和 `CodexRemote-fix-2.4.19-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.4.19-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.20-setup.exe` 和 `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.4.20-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。托盘图标为绿色时，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.4.20 更新内容
+
+- 安装完成后弹出双语提示，由用户选择立即重启 Codex 或稍后手动重启。
+- 安装器不会自动关闭或重启 Codex；选择“稍后”会保持当前会话不受影响。
+- 只有用户明确选择“立即重启”后，才会调用现有安全 SessionController 流程。
 
 ## v2.4.19 更新内容
 
@@ -96,8 +102,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
 `.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此后续每次更新都会
-为 2.4.19 发布提供可直接运行的 `CodexRemote-fix-2.4.19-setup.exe`
-及 `CodexRemote-fix-2.4.19-setup.exe.sha256.txt`。
+为 2.4.20 发布提供可直接运行的 `CodexRemote-fix-2.4.20-setup.exe`
+及 `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`。
 
 每次发布都会在本 README 和 GitHub Release 正文中追加简短的中英文更新说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/build/CodexControlOtherDevices.iss
+++ b/build/CodexControlOtherDevices.iss
@@ -25,7 +25,7 @@ SolidCompression=yes
 WizardStyle=modern
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
-CloseApplications=force
+CloseApplications=no
 RestartApplications=no
 SetupLogging=yes
 MinVersion=10.0.17763
@@ -61,6 +61,7 @@ Source: "..\Start-CodexControlOtherDevices.ps1"; DestDir: "{app}"; Flags: ignore
 Source: "..\Reset-CodexControlOtherDevices.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\Test-CodexControlOtherDevices.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\Prepare-CcodRemoteUpgrade.ps1"; DestDir: "{tmp}"; Flags: dontcopy
+Source: "..\Prompt-CcodRestart.ps1"; DestDir: "{tmp}"; Flags: dontcopy
 
 [InstallDelete]
 Type: files; Name: "{userprograms}\Codex Control other devices\Codex Control other devices for Windows.lnk"
@@ -118,5 +119,22 @@ begin
       Result := 'The previous CodexRemote-fix supervisor could not be stopped safely.';
   except
     Result := 'The previous CodexRemote-fix supervisor could not be stopped safely.';
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  ResultCode: Integer;
+  ScriptPath: String;
+  Parameters: String;
+begin
+  if (CurStep <> ssPostInstall) or WizardSilent then
+    Exit;
+  try
+    ExtractTemporaryFile('Prompt-CcodRestart.ps1');
+    ScriptPath := ExpandConstant('{tmp}\Prompt-CcodRestart.ps1');
+    Parameters := '-NoProfile -ExecutionPolicy Bypass -File "' + ScriptPath + '" -AppRoot "' + ExpandConstant('{app}') + '" -InstallRoot "' + ExpandConstant('{localappdata}\CodexControlOtherDevices') + '"';
+    Exec(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'), Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  except
   end;
 end;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/trayhost/AssemblyInfo.cs
+++ b/src/trayhost/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Persistent native tray host for CodexRemote-fix")]
 [assembly: AssemblyCompany("CodexRemote-fix contributors")]
 [assembly: AssemblyProduct("CodexRemote-fix")]
-[assembly: AssemblyVersion("2.4.19.0")]
-[assembly: AssemblyFileVersion("2.4.19.0")]
+[assembly: AssemblyVersion("2.4.20.0")]
+[assembly: AssemblyFileVersion("2.4.20.0")]
 [assembly: ComVisible(false)]

--- a/src/trayhost/CodexRemote.TrayHost.manifest
+++ b/src/trayhost/CodexRemote.TrayHost.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.4.19.0" name="CodexRemote.fix.TrayHost" type="win32" />
+  <assemblyIdentity version="2.4.20.0" name="CodexRemote.fix.TrayHost" type="win32" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1112,28 +1112,31 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.19 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.20 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.4.19' ([string]$package.version) 'package version is exactly 2.4.19'
+    Assert-CcodEqual '2.4.20' ([string]$package.version) 'package version is exactly 2.4.20'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.4.19-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.20-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.4.19-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.20-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 $results += Invoke-CcodTest 'installer stops the running supervisor before replacing the installed version' {
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw -Encoding UTF8
     $prepareScript = Join-Path $repositoryRoot 'Prepare-CcodRemoteUpgrade.ps1'
+    $promptScript = Join-Path $repositoryRoot 'Prompt-CcodRestart.ps1'
     Assert-CcodTrue (Test-Path -LiteralPath $prepareScript -PathType Leaf) 'pre-upgrade supervisor stopper exists'
-    Assert-CcodTrue ($installerScript -cmatch '(?m)^CloseApplications=force\r?$') 'installer requests forced application closure'
+    Assert-CcodTrue (Test-Path -LiteralPath $promptScript -PathType Leaf) 'post-install Codex restart prompt exists'
+    Assert-CcodTrue ($installerScript -cmatch '(?m)^CloseApplications=no\r?$') 'installer never lets Restart Manager close Codex'
     Assert-CcodTrue ($installerScript -cmatch '(?m)^function PrepareToInstall\(') 'installer runs the pre-upgrade hook'
     Assert-CcodTrue ($installerScript -cmatch 'Prepare-CcodRemoteUpgrade\.ps1') 'installer bundles and invokes the pre-upgrade supervisor stopper'
+    Assert-CcodTrue ($installerScript -cmatch '(?s)CurStepChanged.*ssPostInstall.*Prompt-CcodRestart\.ps1') 'installer prompts after post-install completion'
 }
 
 $results += Invoke-CcodTest 'pre-upgrade supervisor stopper exits cleanly when no old runtime is present' {
@@ -1141,6 +1144,17 @@ $results += Invoke-CcodTest 'pre-upgrade supervisor stopper exits cleanly when n
     try {
         $output = @(& (Join-Path $repositoryRoot 'Prepare-CcodRemoteUpgrade.ps1') -InstallRoot $root 2>&1)
         Assert-CcodEqual 0 $LASTEXITCODE 'pre-upgrade helper no-op exits successfully without an installed supervisor'
+    } finally {
+        if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+$results += Invoke-CcodTest 'post-install restart prompt does nothing when the user chooses later' {
+    $root = Join-Path ([IO.Path]::GetTempPath()) ('ccod-restart-prompt-later-' + [guid]::NewGuid().ToString('N'))
+    try {
+        $output = @(& (Join-Path $repositoryRoot 'Prompt-CcodRestart.ps1') -AppRoot $repositoryRoot -InstallRoot $root -Choice Later 2>&1)
+        Assert-CcodEqual 0 $LASTEXITCODE 'later choice exits successfully'
+        Assert-CcodTrue (($output -join "`n") -notmatch '(?i)Start-CodexControlOtherDevices') 'later choice does not launch the restart wrapper'
     } finally {
         if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
     }
@@ -1227,16 +1241,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.19-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/TrayHostBuild.SelfTest.ps1
+++ b/tests/persistence/TrayHostBuild.SelfTest.ps1
@@ -38,12 +38,12 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
     Import-Module $modulePath -Force
     $artifact=Join-Path $env:TEMP ('ccod-trayhost-artifact-'+[Guid]::NewGuid().ToString('N'))
     try{
-        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.4.19' -OutputDirectory $artifact
+        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.4.20' -OutputDirectory $artifact
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe') -PathType Leaf) 'TrayHost executable exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe.config') -PathType Leaf) 'TrayHost config exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -PathType Leaf) 'TrayHost provenance exists'
         $provenance=Get-Content -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -Raw|ConvertFrom-Json
-        Assert-CcodEqual '2.4.19' ([string]$provenance.version) 'provenance version is exact'
+        Assert-CcodEqual '2.4.20' ([string]$provenance.version) 'provenance version is exact'
         $icon=Join-Path $repositoryRoot 'assets\codexremote-fix\codexremote-fix.ico'
         Assert-CcodTrue (Test-Path -LiteralPath $icon -PathType Leaf) 'TrayHost product ICO exists'
         $iconSha=[Security.Cryptography.SHA256]::Create();try{$iconHash=([BitConverter]::ToString($iconSha.ComputeHash([IO.File]::ReadAllBytes($icon)))).Replace('-','').ToLowerInvariant()}finally{$iconSha.Dispose()}
@@ -51,7 +51,7 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
         Assert-CcodTrue (@($provenance.sourceFiles).Count -ge 10) 'provenance includes every TrayHost source'
         Assert-CcodTrue (-not ([string]$provenance|Select-String -Pattern '[A-Za-z]:\\|\\\\' -Quiet)) 'provenance does not leak absolute paths'
         $tampered=Join-Path $artifact 'CodexRemote.TrayHost.exe.config'; Add-Content -LiteralPath $tampered -Value 'x'
-        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.4.19' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
+        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.4.20' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
         Assert-CcodTrue $threw 'tampered artifact is rejected'
     }finally{if(Test-Path -LiteralPath $artifact){Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue}}
 }


### PR DESCRIPTION
Adds a bilingual post-install prompt with Restart now/Later choices. The installer no longer lets Restart Manager close Codex; choosing Later leaves the current session untouched, while Restart now invokes the existing safe SessionController path. Includes PowerShell 5.1-compatible prompt tests and v2.4.20 release metadata.