### PR TITLE
ci: publish English-only release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,16 @@ jobs:
           $tag = $env:GITHUB_REF_NAME
           $version = $tag.TrimStart('v')
           $changelog = Get-Content -LiteralPath (Join-Path $PWD 'CHANGELOG.md') -Raw -Encoding UTF8
-          $section = [regex]::Match($changelog, '(?ms)^## ' + [regex]::Escape($tag) + '\r?\n(.*?)(?=^## |\z)')
-          if (-not $section.Success) {
-            throw "CHANGELOG.md has no bilingual section for $tag"
+          $releaseSection = [regex]::Match($changelog, '(?ms)^## ' + [regex]::Escape($tag) + '\r?\n(.*?)(?=^## |\z)')
+          if (-not $releaseSection.Success) {
+            throw "CHANGELOG.md has no release section for $tag"
+          }
+          $englishSection = [regex]::Match($releaseSection.Groups[1].Value, '(?ms)^### English\r?\n(.*?)(?=^### |\z)')
+          if (-not $englishSection.Success) {
+            throw "CHANGELOG.md has no English release section for $tag"
           }
           $notesPath = Join-Path $env:RUNNER_TEMP ("CodexRemote-fix-$tag-release-notes.md")
-          Set-Content -LiteralPath $notesPath -Value ("# CodexRemote-fix $version`n`n" + $section.Groups[1].Value.Trim() + "`n") -Encoding UTF8
+          Set-Content -LiteralPath $notesPath -Value ("# CodexRemote-fix $version`n`n" + $englishSection.Groups[1].Value.Trim() + "`n") -Encoding UTF8
           $exists = $null -ne (gh release view $tag --repo $env:GITHUB_REPOSITORY 2>$null)
           if (-not $exists) {
             gh release create $tag --repo $env:GITHUB_REPOSITORY --title "CodexRemote-fix $version" --notes-file $notesPath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ No unreleased changes.
 
 ### English
 
-- Added a bilingual post-install prompt: restart Codex now or restart it manually later.
+- Added a localized post-install prompt: restart Codex now or restart it manually later.
 - The installer never closes or restarts Codex automatically; **Later** leaves the current session untouched.
 - **Restart now** invokes the existing safe SessionController path only after explicit confirmation.
 

--- a/Prompt-CcodRestart.ps1
+++ b/Prompt-CcodRestart.ps1
@@ -2,7 +2,8 @@
 param(
     [Parameter(Mandatory)][string]$AppRoot,
     [string]$InstallRoot,
-    [ValidateSet('Restart','Later')][string]$Choice
+    [ValidateSet('Restart','Later')][string]$Choice,
+    [switch]$PreviewChinese
 )
 
 $ErrorActionPreference = 'Stop'
@@ -23,20 +24,23 @@ function Resolve-CcodPromptLanguage {
     return 'en-US'
 }
 
+function Get-CcodRestartPromptText {
+    param([string]$Language)
+    if ($Language -eq 'zh-CN') {
+        $localized = ('{"title":"CodexRemote-fix","message":"\u9700\u8981\u91cd\u542f Codex \u624d\u80fd\u751f\u6548\u3002\r\n\r\n\u7acb\u5373\u91cd\u542f Codex \u5417\uff1f\r\n\u9009\u62e9 Yes \u7acb\u5373\u91cd\u542f\uff0c\u9009\u62e9 No \u7a0d\u540e\u624b\u52a8\u91cd\u542f\u3002"}' | ConvertFrom-Json)
+        return [pscustomobject][ordered]@{Title=[string]$localized.title;Message=[string]$localized.message}
+    } else {
+        return [pscustomobject][ordered]@{Title='CodexRemote-fix';Message="Codex must be restarted for the fix to take effect.`r`n`r`nRestart Codex now?`r`nChoose Yes to restart now, or No to restart it manually later."}
+    }
+}
+
 function Show-CcodRestartPrompt {
     param([string]$Language)
     Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
-    if ($Language -eq 'zh-CN') {
-        $localized = ('{"title":"CodexRemote-fix","message":"\\u9700\\u8981\\u91cd\\u542f Codex \\u624d\\u80fd\\u751f\\u6548\\u3002\\r\\n\\r\\n\\u7acb\\u5373\\u91cd\\u542f Codex \\u5417\\uff1f\\r\\n\\u9009\\u62e9 Yes \\u7acb\\u5373\\u91cd\\u542f\\uff0c\\u9009\\u62e9 No \\u7a0d\\u540e\\u624b\\u52a8\\u91cd\\u542f\\u3002"}' | ConvertFrom-Json)
-        $title = [string]$localized.title
-        $message = [string]$localized.message
-    } else {
-        $title = 'CodexRemote-fix'
-        $message = "Codex must be restarted for the fix to take effect.`r`n`r`nRestart Codex now?`r`nChoose Yes to restart now, or No to restart it manually later."
-    }
+    $text = Get-CcodRestartPromptText -Language $Language
     $result = [Windows.Forms.MessageBox]::Show(
-        $message,
-        $title,
+        $text.Message,
+        $text.Title,
         [Windows.Forms.MessageBoxButtons]::YesNo,
         [Windows.Forms.MessageBoxIcon]::Information,
         [Windows.Forms.MessageBoxDefaultButton]::Button2
@@ -44,6 +48,9 @@ function Show-CcodRestartPrompt {
     if ($result -eq [Windows.Forms.DialogResult]::Yes) { return 'Restart' }
     return 'Later'
 }
+
+$preview = if ($PreviewChinese) { Get-CcodRestartPromptText -Language 'zh-CN' } else { $null }
+if ($null -ne $preview) { Write-Output $preview.Message; exit 0 }
 
 $selected = if ([string]::IsNullOrWhiteSpace($Choice)) { Show-CcodRestartPrompt -Language (Resolve-CcodPromptLanguage -Root $InstallRoot) } else { $Choice }
 if ($selected -ceq 'Later') { exit 0 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ supervisor are working.
 
 ## What's new in v2.4.20
 
-- After installation, show a bilingual prompt: restart Codex now or restart it manually later.
+- After installation, show a localized prompt: restart Codex now or restart it manually later.
 - The installer never closes or restarts Codex automatically; choosing **Later** leaves the current session untouched.
 - Choosing **Restart now** invokes the existing safe SessionController path only after explicit user confirmation.
 
@@ -112,8 +112,8 @@ The `.github/workflows/release.yml` workflow builds the installer from the tag a
 so the 2.4.20 release includes the ready-to-run `CodexRemote-fix-2.4.20-setup.exe`
 and `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`.
 
-Each release appends a short bilingual change summary to this README and to the GitHub release body.
-The full history is in [CHANGELOG.md](CHANGELOG.md).
+Each release appends a short English change summary to the GitHub release body. The README and
+[CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.
 
 After a Codex Desktop update, check the [Releases](https://github.com/naipi11/CodexRemote-fix/releases)
 page for a newer installer, or run the **CodexRemote-fix compatibility check** shortcut from the Start menu

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1261,6 +1261,8 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($workflow -cmatch '(?m)^name: CodexRemote-fix release\r?$') 'release workflow uses public product branding'
     Assert-CcodTrue ($workflow -cmatch '(?m)^\s+name: CodexRemote-fix installer\r?$') 'uploaded artifact uses public product branding'
     Assert-CcodTrue ($workflow -cmatch '--title "CodexRemote-fix \$version"') 'GitHub release title uses public product branding'
+    Assert-CcodTrue ($workflow -cmatch 'englishSection = \[regex\]::Match') 'GitHub release notes extract the English changelog section only'
+    Assert-CcodTrue ($workflow -cmatch 'has no English release section') 'release fails clearly when the English changelog section is missing'
 }
 
 $results += Invoke-CcodTest 'installer carries the Inno contract needed by its self-validation' {

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1160,6 +1160,14 @@ $results += Invoke-CcodTest 'post-install restart prompt does nothing when the u
     }
 }
 
+$results += Invoke-CcodTest 'Chinese restart prompt decodes its Unicode text before display' {
+    $output = @(& (Join-Path $repositoryRoot 'Prompt-CcodRestart.ps1') -AppRoot $repositoryRoot -PreviewChinese 2>&1)
+    Assert-CcodEqual 0 $LASTEXITCODE 'Chinese prompt preview exits successfully'
+    $text = $output -join "`n"
+    Assert-CcodTrue ($text -notmatch '\\u[0-9a-fA-F]{4}') 'Chinese prompt never exposes Unicode escape literals'
+    Assert-CcodTrue ($text -match 'Codex' -and $text.Length -gt 20) 'Chinese prompt contains decoded restart text'
+}
+
 $results += Invoke-CcodTest 'CodexRemote-fix icon is a bounded multi-resolution PNG ICO' {
     $iconPath = Join-Path $repositoryRoot 'assets\codexremote-fix\codexremote-fix.ico'
     Assert-CcodTrue (Test-Path -LiteralPath $iconPath -PathType Leaf) 'public product ICO exists'
@@ -1256,6 +1264,8 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
 
     Assert-CcodTrue ($readme -cmatch 'uninstall \*\*CodexRemote-fix\*\* from') 'English uninstall instructions use the public product name'
     Assert-CcodTrue ($readmeChinese -cmatch '(?s)Windows .{0,100}\*\*CodexRemote-fix\*\*') 'Chinese uninstall instructions use the public product name'
+    Assert-CcodTrue ($readme -cmatch 'Each release appends a short English change summary to the GitHub release body') 'README documents English-only GitHub release notes'
+    Assert-CcodTrue ($readme -cnotmatch 'bilingual change summary to this README and to the GitHub release body') 'README does not promise bilingual GitHub release notes'
 
     $workflow = Get-Content -LiteralPath (Join-Path $repositoryRoot '.github\workflows\release.yml') -Raw -Encoding UTF8
     Assert-CcodTrue ($workflow -cmatch '(?m)^name: CodexRemote-fix release\r?$') 'release workflow uses public product branding'


### PR DESCRIPTION
Future GitHub Releases now publish only the English section from CHANGELOG.md. README and CHANGELOG remain bilingual. v2.4.20's existing Release body was updated to English-only.