### PR TITLE
Fix installer runtime activation and explicit Codex restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ No unreleased changes.
 
 - Added an English post-install prompt: restart Codex now or restart it manually later.
 - The installer never closes or restarts Codex automatically; **Later** leaves the current session untouched.
-- **Restart now** invokes the existing safe SessionController path only after explicit confirmation.
+- The installer now stops the persistent prior supervisor, validates the packaged TrayHost payload, and prompts only after the new runtime is active.
+- **Restart now** safely closes the current Codex session and launches a fresh controlled session after explicit confirmation.
 
 ### 简体中文
 
 - 安装完成后新增英文提示，可选择立即重启 Codex 或稍后手动重启。
 - 安装器不会自动关闭或重启 Codex；选择“稍后”会保持当前会话不受影响。
-- 只有明确选择“立即重启”后，才调用现有安全 SessionController 流程。
+- 安装器会关闭持久运行时中的旧 Supervisor，验证打包 TrayHost，并且只在新运行时已激活后提示。
+- 只有明确选择“立即重启”后，才会安全关闭当前 Codex 并启动新的受控会话。
 
 ## v2.4.19
 

--- a/Prompt-CcodRestart.ps1
+++ b/Prompt-CcodRestart.ps1
@@ -36,9 +36,17 @@ $selected = if ([string]::IsNullOrWhiteSpace($Choice)) { Show-CcodRestartPrompt 
 if ($selected -ceq 'Later') { exit 0 }
 
 $startScript = [IO.Path]::GetFullPath((Join-Path $AppRoot 'Start-CodexControlOtherDevices.ps1'))
-if (-not [IO.File]::Exists($startScript)) { exit 1 }
+if (-not [IO.File]::Exists($startScript)) {
+    Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+    [Windows.Forms.MessageBox]::Show('Codex could not be restarted automatically. Please restart Codex manually.', 'CodexRemote-fix', [Windows.Forms.MessageBoxButtons]::OK, [Windows.Forms.MessageBoxIcon]::Error) | Out-Null
+    exit 1
+}
 $powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
-$arguments = @('-NoProfile','-ExecutionPolicy','Bypass','-File',$startScript)
+$arguments = @('-NoProfile','-ExecutionPolicy','Bypass','-File',$startScript,'-RestartCodex')
 $null = & $powershell @arguments 2>$null
-if ($LASTEXITCODE -ne 0) { exit 1 }
+if ($LASTEXITCODE -ne 0) {
+    Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+    [Windows.Forms.MessageBox]::Show('Codex could not be restarted automatically. Please restart Codex manually.', 'CodexRemote-fix', [Windows.Forms.MessageBoxButtons]::OK, [Windows.Forms.MessageBoxIcon]::Error) | Out-Null
+    exit 1
+}
 exit 0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ supervisor are working.
 
 - After installation, show an English prompt: restart Codex now or restart it manually later.
 - The installer never closes or restarts Codex automatically; choosing **Later** leaves the current session untouched.
-- Choosing **Restart now** invokes the existing safe SessionController path only after explicit user confirmation.
+- The installer now stops the prior CodexRemote-fix supervisor from its persistent runtime, validates the packaged TrayHost payload, and shows the prompt only after the new runtime is active.
+- Choosing **Restart now** safely closes the current Codex session and launches a fresh controlled session after explicit user confirmation.
 
 ## What's new in v2.4.19
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 - 安装完成后弹出英文提示，由用户选择立即重启 Codex 或稍后手动重启。
 - 安装器不会自动关闭或重启 Codex；选择“稍后”会保持当前会话不受影响。
-- 只有用户明确选择“立即重启”后，才会调用现有安全 SessionController 流程。
+- 安装器会从持久运行时可靠关闭旧 CodexRemote-fix Supervisor，验证打包的 TrayHost，并且只在新运行时已激活后显示提示。
+- 只有用户明确选择“立即重启”后，才会安全关闭当前 Codex 并启动新的受控会话。
 
 ## v2.4.19 更新内容
 

--- a/Start-CodexControlOtherDevices.ps1
+++ b/Start-CodexControlOtherDevices.ps1
@@ -2,7 +2,8 @@
 param(
     [ValidateRange(0,65535)][int]$RendererDebugPort=0,
     [ValidateRange(0,65535)][int]$MainInspectorPort=0,
-    [ValidateRange(10,120)][int]$TimeoutSeconds=30
+    [ValidateRange(10,120)][int]$TimeoutSeconds=30,
+    [switch]$RestartCodex
 )
 
 $ErrorActionPreference='Stop'
@@ -38,6 +39,14 @@ function New-CcodStartControllerRequest {
     }
 }
 
+function New-CcodRestartControllerRequest {
+    param([string]$RuntimeId,[int]$TimeoutSeconds,$SupervisorIdentity=(Get-CcodStartSupervisorIdentity),[string]$TransactionId=([guid]::NewGuid().ToString('D')))
+    [pscustomobject][ordered]@{
+        schemaVersion=1;action='Recover';transactionId=$TransactionId;runtimeId=$RuntimeId;supervisorIdentity=$SupervisorIdentity;source=$null;existingOnly=$true
+        rendererPort=$null;mainPort=$null;timeoutMilliseconds=[int]($TimeoutSeconds*1000);restartOrdinary=$false
+    }
+}
+
 function New-CcodStartControllerArguments {
     param([string]$Controller,[string]$RequestPath,[string]$ResultPath)
     @('-NoProfile','-ExecutionPolicy','Bypass','-File',$Controller,'-RequestPath',$RequestPath,'-ResultPath',$ResultPath)
@@ -57,19 +66,34 @@ function Invoke-CcodStartInstalledController {
         $lines=@($stdout|ForEach-Object{[string]$_}|Where-Object{-not [string]::IsNullOrWhiteSpace($_)})
         if($lines.Count -ne 1 -or -not [IO.File]::Exists($resultPath)){throw 'Installed controller did not return one persisted machine-readable result.'}
         try{$fromStdout=$lines[0]|ConvertFrom-Json -ErrorAction Stop;$result=Get-Content -LiteralPath $resultPath -Raw|ConvertFrom-Json -ErrorAction Stop}catch{throw 'Installed controller returned invalid JSON.'}
-        if(($fromStdout|ConvertTo-Json -Depth 16 -Compress) -cne ($result|ConvertTo-Json -Depth 16 -Compress) -or $result.transactionId -cne $Request.transactionId -or $result.action -cne 'Apply' -or $result.outcome -isnot [string]){throw 'Installed controller result is incomplete or uncorrelated.'}
-        if($exitCode -ne 0 -or $result.ok -ne $true){throw "Session activation failed safely: $($result.error.code) $($result.error.message)"}
+        if(($fromStdout|ConvertTo-Json -Depth 16 -Compress) -cne ($result|ConvertTo-Json -Depth 16 -Compress) -or $result.transactionId -cne $Request.transactionId -or $result.action -cne $Request.action -or $result.outcome -isnot [string]){throw 'Installed controller result is incomplete or uncorrelated.'}
+        if($exitCode -ne 0 -or $result.ok -ne $true){throw "Session $($Request.action) failed safely: $($result.error.code) $($result.error.message)"}
         return $result
     }finally{
         foreach($path in @($requestPath,$resultPath,$stderrPath)){if([IO.File]::Exists($path)){[IO.File]::Delete($path)}}
     }
 }
 
+function Invoke-CcodRestartInstalledWorkflow {
+    param($Resolved,$RestartRequest,$ApplyRequest)
+    $close=Invoke-CcodStartInstalledController -Resolved $Resolved -Request $RestartRequest
+    if($close.outcome -notin @('Closed','NoAction')){throw "Codex restart could not safely close the current session: $($close.outcome)"}
+    $apply=Invoke-CcodStartInstalledController -Resolved $Resolved -Request $ApplyRequest
+    if($apply.outcome -notin @('Activated','NoAction')){throw "Codex restart did not activate the controlled session: $($apply.outcome)"}
+    return [pscustomobject][ordered]@{Close=$close;Apply=$apply}
+}
+
 if($MyInvocation.InvocationName -ne '.'){
     $installRoot=[IO.Path]::GetFullPath((Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'CodexControlOtherDevices'))
     $resolved=Resolve-CcodStartInstalledController -InstallRoot $installRoot
     $request=New-CcodStartControllerRequest -RuntimeId $resolved.RuntimeId -RendererDebugPort $RendererDebugPort -MainInspectorPort $MainInspectorPort -TimeoutSeconds $TimeoutSeconds
-    $result=Invoke-CcodStartInstalledController -Resolved $resolved -Request $request
+    if($RestartCodex){
+        $restart=New-CcodRestartControllerRequest -RuntimeId $resolved.RuntimeId -TimeoutSeconds $TimeoutSeconds
+        $workflow=Invoke-CcodRestartInstalledWorkflow -Resolved $resolved -RestartRequest $restart -ApplyRequest $request
+        $result=$workflow.Apply
+    }else{
+        $result=Invoke-CcodStartInstalledController -Resolved $resolved -Request $request
+    }
     Write-Host ''
     Write-Host 'CodexRemote-fix is enabled for this app session.' -ForegroundColor Green
     Write-Host 'Open Settings > Connections > Control other devices.'

--- a/build/CodexControlOtherDevices.iss
+++ b/build/CodexControlOtherDevices.iss
@@ -74,9 +74,6 @@ Type: files; Name: "{userprograms}\Codex Control other devices\Uninstall CodexRe
 Type: dirifempty; Name: "{userprograms}\Codex Control other devices"
 Type: files; Name: "{userdesktop}\Codex 设备连接 (Device Connection).lnk"
 
-[Run]
-Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\Install-CodexControlOtherDevices.ps1"" -EnableCandidateCompatibleUpdates"; Flags: runhidden waituntilterminated; StatusMsg: "Installing CodexRemote-fix..."
-
 [UninstallRun]
 Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\Uninstall-CodexControlOtherDevices.ps1"" -BackupDeviceKeyStore"; Flags: runhidden waituntilterminated; RunOnceId: "UninstallCodexControlOtherDevices"
 
@@ -92,9 +89,19 @@ begin
   Result := RegKeyExists(HKCU64, 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{{2B9E9F2E-7A32-4A7E-9C1D-9F5B5C6D7E8F}_is1');
 end;
 
+function HasPersistentRuntime(): Boolean;
+begin
+  Result := FileExists(ExpandConstant('{localappdata}\CodexControlOtherDevices\active.json'));
+end;
+
+function HasExistingRuntime(): Boolean;
+begin
+  Result := IsAppInstalled() or HasPersistentRuntime();
+end;
+
 function InitializeSetup(): Boolean;
 begin
-  if IsAppInstalled() then
+  if HasExistingRuntime() and not WizardSilent then
     MsgBox('CodexRemote-fix is already installed. The current supervisor will be stopped safely before the new runtime replaces the old one; device keys and state are preserved.', mbInformation, MB_OK);
   Result := True;
 end;
@@ -107,7 +114,7 @@ var
 begin
   Result := '';
   NeedsRestart := False;
-  if not IsAppInstalled() then
+  if not HasExistingRuntime() then
     Exit;
   try
     ExtractTemporaryFile('Prepare-CcodRemoteUpgrade.ps1');
@@ -122,13 +129,46 @@ begin
   end;
 end;
 
+procedure ShowRuntimeActivationFailure(const Message: String);
+begin
+  if not WizardSilent then
+    MsgBox(Message, mbError, MB_OK);
+end;
+
+function InstallPersistentRuntimeOrAbort(): Boolean;
+var
+  ResultCode: Integer;
+  Parameters: String;
+begin
+  Result := False;
+  try
+    WizardForm.StatusLabel.Caption := 'Activating the new CodexRemote-fix runtime...';
+    Parameters := '-NoProfile -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\Install-CodexControlOtherDevices.ps1') + '" -EnableCandidateCompatibleUpdates';
+    if not Exec(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'), Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then begin
+      ShowRuntimeActivationFailure('CodexRemote-fix could not start its runtime upgrade. The existing runtime was kept unchanged; no Codex restart was attempted.');
+      Exit;
+    end;
+    if ResultCode <> 0 then begin
+      ShowRuntimeActivationFailure('CodexRemote-fix could not activate the new runtime. The existing runtime was kept unchanged; no Codex restart was attempted. Close CodexRemote-fix from the tray and run the installer again.');
+      Exit;
+    end;
+    Result := True;
+  except
+    ShowRuntimeActivationFailure('CodexRemote-fix could not activate the new runtime. The existing runtime was kept unchanged; no Codex restart was attempted.');
+  end;
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   ResultCode: Integer;
   ScriptPath: String;
   Parameters: String;
 begin
-  if (CurStep <> ssPostInstall) or WizardSilent then
+  if CurStep <> ssPostInstall then
+    Exit;
+  if not InstallPersistentRuntimeOrAbort() then
+    Abort;
+  if WizardSilent then
     Exit;
   try
     ExtractTemporaryFile('Prompt-CcodRestart.ps1');

--- a/src/persistence/modules/InstallLifecycle.psm1
+++ b/src/persistence/modules/InstallLifecycle.psm1
@@ -151,7 +151,10 @@ function Test-CcodLifecycleRemovePath {
 }
 
 function Get-CcodLifecycleSourceFiles {
-    param([Parameter(Mandatory)][string]$SourceRoot)
+    param(
+        [Parameter(Mandatory)][string]$SourceRoot,
+        [switch]$RequireTrayHost
+    )
 
     $root = Get-CcodLifecycleCanonicalRoot -Path $SourceRoot -Kind 'Source root'
     if (-not [IO.Directory]::Exists($root)) {
@@ -172,22 +175,23 @@ function Get-CcodLifecycleSourceFiles {
     )
     foreach ($leaf in $required) { $relative.Add($leaf) }
     $trayHostRoot = Join-Path $root 'bin'
-    if (-not [IO.Directory]::Exists($trayHostRoot)) {
-        Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_INCOMPLETE' 'TrayHost artifact directory is missing.' $trayHostRoot
-    }
-    $expectedTrayHost = @('CodexRemote.TrayHost.exe','CodexRemote.TrayHost.exe.config','trayhost-build-provenance.json')
-    $actualTrayHost = @(Get-ChildItem -LiteralPath $trayHostRoot -Force -ErrorAction Stop)
-    if (@($actualTrayHost | Where-Object { $_.PSIsContainer -or $expectedTrayHost -cnotcontains $_.Name }).Count -gt 0 -or
-        (@($actualTrayHost.Name | Sort-Object) -join ',') -cne (@($expectedTrayHost | Sort-Object) -join ',')) {
-        Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_INCOMPLETE' 'TrayHost artifact set is incomplete or contains unknown files.' $trayHostRoot
-    }
-    foreach ($trayFile in $actualTrayHost) {
-        $trayReparse = Test-CcodLifecycleReparse -Path $trayFile.FullName
-        $trayAds = Test-CcodLifecycleAlternateDataStreams -Path $trayFile.FullName
-        if ($trayReparse -or $trayAds) {
-            Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_REPARSE' 'TrayHost artifact is a reparse point or has alternate data streams.' $trayFile.FullName
+    if ([IO.Directory]::Exists($trayHostRoot)) {
+        $expectedTrayHost = @('CodexRemote.TrayHost.exe','CodexRemote.TrayHost.exe.config','trayhost-build-provenance.json')
+        $actualTrayHost = @(Get-ChildItem -LiteralPath $trayHostRoot -Force -ErrorAction Stop)
+        if (@($actualTrayHost | Where-Object { $_.PSIsContainer -or $expectedTrayHost -cnotcontains $_.Name }).Count -gt 0 -or
+            (@($actualTrayHost.Name | Sort-Object) -join ',') -cne (@($expectedTrayHost | Sort-Object) -join ',')) {
+            Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_INCOMPLETE' 'TrayHost artifact set is incomplete or contains unknown files.' $trayHostRoot
         }
-        $relative.Add('bin\' + $trayFile.Name)
+        foreach ($trayFile in $actualTrayHost) {
+            $trayReparse = Test-CcodLifecycleReparse -Path $trayFile.FullName
+            $trayAds = Test-CcodLifecycleAlternateDataStreams -Path $trayFile.FullName
+            if ($trayReparse -or $trayAds) {
+                Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_REPARSE' 'TrayHost artifact is a reparse point or has alternate data streams.' $trayFile.FullName
+            }
+            $relative.Add('bin\' + $trayFile.Name)
+        }
+    } elseif ($RequireTrayHost) {
+        Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_INCOMPLETE' 'TrayHost artifact directory is missing.' $trayHostRoot
     }
     $runtimeRoot = Join-Path $root 'src\runtime'
     foreach ($item in Get-ChildItem -LiteralPath $runtimeRoot -Force -Recurse -ErrorAction Stop) {
@@ -591,7 +595,7 @@ function Get-CcodLifecycleAdapters {
         ValidateSource = {
             param($SourceRoot)
             try {
-                $files = @(Get-CcodLifecycleSourceFiles -SourceRoot $SourceRoot)
+                $files = @(Get-CcodLifecycleSourceFiles -SourceRoot $SourceRoot -RequireTrayHost)
                 return $files.Count -gt 0
             } catch {
                 return $false
@@ -892,7 +896,7 @@ function Invoke-CcodInstall {
     }
     $projectVersion = & $adapters.GetProjectVersion $sourceRoot
     $nodeCandidates = @(Get-CcodLifecycleNodeCandidates -Adapters $adapters)
-    $files = @(Get-CcodLifecycleSourceFiles -SourceRoot $sourceRoot)
+    $files = @(Get-CcodLifecycleSourceFiles -SourceRoot $sourceRoot -RequireTrayHost)
 
     $existingPointer = $null
     $activePath = Join-Path $root 'active.json'

--- a/src/persistence/modules/InstallLifecycle.psm1
+++ b/src/persistence/modules/InstallLifecycle.psm1
@@ -172,21 +172,22 @@ function Get-CcodLifecycleSourceFiles {
     )
     foreach ($leaf in $required) { $relative.Add($leaf) }
     $trayHostRoot = Join-Path $root 'bin'
-    if ([IO.Directory]::Exists($trayHostRoot)) {
-        $expectedTrayHost = @('CodexRemote.TrayHost.exe','CodexRemote.TrayHost.exe.config','trayhost-build-provenance.json')
-        $actualTrayHost = @(Get-ChildItem -LiteralPath $trayHostRoot -Force -ErrorAction Stop)
-        if (@($actualTrayHost | Where-Object { $_.PSIsContainer -or $expectedTrayHost -cnotcontains $_.Name }).Count -gt 0 -or
-            (@($actualTrayHost.Name | Sort-Object) -join ',') -cne (@($expectedTrayHost | Sort-Object) -join ',')) {
-            Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_INCOMPLETE' 'TrayHost artifact set is incomplete or contains unknown files.' $trayHostRoot
+    if (-not [IO.Directory]::Exists($trayHostRoot)) {
+        Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_INCOMPLETE' 'TrayHost artifact directory is missing.' $trayHostRoot
+    }
+    $expectedTrayHost = @('CodexRemote.TrayHost.exe','CodexRemote.TrayHost.exe.config','trayhost-build-provenance.json')
+    $actualTrayHost = @(Get-ChildItem -LiteralPath $trayHostRoot -Force -ErrorAction Stop)
+    if (@($actualTrayHost | Where-Object { $_.PSIsContainer -or $expectedTrayHost -cnotcontains $_.Name }).Count -gt 0 -or
+        (@($actualTrayHost.Name | Sort-Object) -join ',') -cne (@($expectedTrayHost | Sort-Object) -join ',')) {
+        Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_INCOMPLETE' 'TrayHost artifact set is incomplete or contains unknown files.' $trayHostRoot
+    }
+    foreach ($trayFile in $actualTrayHost) {
+        $trayReparse = Test-CcodLifecycleReparse -Path $trayFile.FullName
+        $trayAds = Test-CcodLifecycleAlternateDataStreams -Path $trayFile.FullName
+        if ($trayReparse -or $trayAds) {
+            Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_REPARSE' 'TrayHost artifact is a reparse point or has alternate data streams.' $trayFile.FullName
         }
-        foreach ($trayFile in $actualTrayHost) {
-            $trayReparse = Test-CcodLifecycleReparse -Path $trayFile.FullName
-            $trayAds = Test-CcodLifecycleAlternateDataStreams -Path $trayFile.FullName
-            if ($trayReparse -or $trayAds) {
-                Throw-CcodLifecycleError 'CCOD_INSTALL_SOURCE_REPARSE' 'TrayHost artifact is a reparse point or has alternate data streams.' $trayFile.FullName
-            }
-            $relative.Add('bin\' + $trayFile.Name)
-        }
+        $relative.Add('bin\' + $trayFile.Name)
     }
     $runtimeRoot = Join-Path $root 'src\runtime'
     foreach ($item in Get-ChildItem -LiteralPath $runtimeRoot -Force -Recurse -ErrorAction Stop) {
@@ -589,12 +590,12 @@ function Get-CcodLifecycleAdapters {
     $defaults = @{
         ValidateSource = {
             param($SourceRoot)
-            $validate = [IO.Path]::GetFullPath((Join-Path $SourceRoot 'tests\Validate.ps1'))
-            if (-not [IO.File]::Exists($validate)) { return $false }
-            $powershell = [IO.Path]::GetFullPath((Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'))
-            $arguments = '-NoProfile -ExecutionPolicy Bypass -File "' + $validate + '" -SkipInstalledPackageCheck'
-            $process = Start-Process -FilePath $powershell -ArgumentList $arguments -WindowStyle Hidden -Wait -PassThru
-            try { return $process.ExitCode -eq 0 } finally { $process.Dispose() }
+            try {
+                $files = @(Get-CcodLifecycleSourceFiles -SourceRoot $SourceRoot)
+                return $files.Count -gt 0
+            } catch {
+                return $false
+            }
         }
         GetProjectVersion = { param($SourceRoot) Get-CcodLifecycleProjectVersion -SourceRoot $SourceRoot }
         DiscoverNodeCandidates = {

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -24,6 +24,7 @@ function New-CcodLifecycleSourceFixture {
     New-Item -ItemType Directory -Path (Join-Path $Root 'src\runtime') -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $Root 'src\persistence\modules') -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $Root 'src\persistence\resources') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $Root 'bin') -Force | Out-Null
     [IO.File]::WriteAllText(
         (Join-Path $Root 'package.json'),
         (@{ name = 'codexremote-fix'; version = $Version; private = $true } | ConvertTo-Json -Depth 4),
@@ -45,6 +46,9 @@ function New-CcodLifecycleSourceFixture {
     }
     [IO.File]::WriteAllText((Join-Path $Root 'src\persistence\resources\ui.en-US.json'), '{"schemaVersion":1,"language":"en-US"}', [Text.UTF8Encoding]::new($false))
     [IO.File]::WriteAllText((Join-Path $Root 'src\persistence\resources\ui.zh-CN.json'), '{"schemaVersion":1,"language":"zh-CN"}', [Text.UTF8Encoding]::new($false))
+    foreach ($trayHostFile in @('CodexRemote.TrayHost.exe', 'CodexRemote.TrayHost.exe.config', 'trayhost-build-provenance.json')) {
+        [IO.File]::WriteAllText((Join-Path $Root "bin\$trayHostFile"), "fixture $trayHostFile`r`n", [Text.UTF8Encoding]::new($false))
+    }
     return $Root
 }
 
@@ -195,6 +199,21 @@ function Set-CcodLifecycleTestStatus {
 }
 
 $results = @()
+
+$results += Invoke-CcodTest 'default installer validation uses the structural runtime payload and requires TrayHost files' {
+    $source = New-CcodLifecycleTempRoot
+    try {
+        New-CcodLifecycleSourceFixture -Root $source | Out-Null
+        $module = Get-Module InstallLifecycle
+        $valid = & $module { param($SourceRoot) $adapters = Get-CcodLifecycleAdapters; & $adapters.ValidateSource $SourceRoot } $source
+        Assert-CcodEqual $true $valid 'installer payload validates without running the source test suite'
+        Remove-Item -LiteralPath (Join-Path $source 'bin') -Recurse -Force
+        $missingTrayHost = & $module { param($SourceRoot) $adapters = Get-CcodLifecycleAdapters; & $adapters.ValidateSource $SourceRoot } $source
+        Assert-CcodEqual $false $missingTrayHost 'installer payload rejects a missing TrayHost runtime'
+    } finally {
+        if (Test-Path -LiteralPath $source) { Remove-Item -LiteralPath $source -Recurse -Force }
+    }
+}
 
 $results += Invoke-CcodTest 'first install stages verifies activates task and persists consent' {
     $source = New-CcodLifecycleTempRoot
@@ -1135,8 +1154,13 @@ $results += Invoke-CcodTest 'installer stops the running supervisor before repla
     Assert-CcodTrue (Test-Path -LiteralPath $promptScript -PathType Leaf) 'post-install Codex restart prompt exists'
     Assert-CcodTrue ($installerScript -cmatch '(?m)^CloseApplications=no\r?$') 'installer never lets Restart Manager close Codex'
     Assert-CcodTrue ($installerScript -cmatch '(?m)^function PrepareToInstall\(') 'installer runs the pre-upgrade hook'
+    Assert-CcodTrue ($installerScript -cmatch '(?m)^function HasPersistentRuntime\(') 'installer detects a persistent runtime even if the uninstall key is unavailable'
+    Assert-CcodTrue ($installerScript -cmatch 'if HasExistingRuntime\(\) and not WizardSilent then') 'silent upgrades do not block on the informational existing-installation dialog'
     Assert-CcodTrue ($installerScript -cmatch 'Prepare-CcodRemoteUpgrade\.ps1') 'installer bundles and invokes the pre-upgrade supervisor stopper'
-    Assert-CcodTrue ($installerScript -cmatch '(?s)CurStepChanged.*ssPostInstall.*Prompt-CcodRestart\.ps1') 'installer prompts after post-install completion'
+    Assert-CcodTrue ($installerScript -cmatch '(?m)^function InstallPersistentRuntimeOrAbort\(') 'installer checks the persistent runtime activation result before continuing'
+    Assert-CcodTrue ($installerScript -cmatch '(?m)^procedure ShowRuntimeActivationFailure\(') 'silent upgrades have a dedicated non-blocking runtime activation error path'
+    Assert-CcodTrue ($installerScript -cnotmatch '(?ms)^\[Run\]\s*\r?\nFilename: "powershell\.exe"; Parameters: ".*Install-CodexControlOtherDevices\.ps1') 'installer does not silently ignore its runtime installer exit code through a Run entry'
+    Assert-CcodTrue ($installerScript -cmatch '(?s)CurStepChanged.*InstallPersistentRuntimeOrAbort.*Prompt-CcodRestart\.ps1') 'installer prompts only after the persistent runtime activation succeeds'
 }
 
 $results += Invoke-CcodTest 'pre-upgrade supervisor stopper exits cleanly when no old runtime is present' {
@@ -1155,6 +1179,27 @@ $results += Invoke-CcodTest 'post-install restart prompt does nothing when the u
         $output = @(& (Join-Path $repositoryRoot 'Prompt-CcodRestart.ps1') -AppRoot $repositoryRoot -InstallRoot $root -Choice Later 2>&1)
         Assert-CcodEqual 0 $LASTEXITCODE 'later choice exits successfully'
         Assert-CcodTrue (($output -join "`n") -notmatch '(?i)Start-CodexControlOtherDevices') 'later choice does not launch the restart wrapper'
+    } finally {
+        if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+$results += Invoke-CcodTest 'post-install restart prompt requests an explicit controlled Codex restart after Yes' {
+    $root = Join-Path ([IO.Path]::GetTempPath()) ('ccod-restart-prompt-yes-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [IO.Directory]::CreateDirectory($root) | Out-Null
+        $marker = Join-Path $root 'restart-marker.txt'
+        $startScript = Join-Path $root 'Start-CodexControlOtherDevices.ps1'
+        $source = @"
+param([switch]`$RestartCodex)
+[IO.File]::WriteAllText('$marker', [string]`$RestartCodex, [Text.UTF8Encoding]::new(`$false))
+exit 0
+"@
+        [IO.File]::WriteAllText($startScript, $source, [Text.UTF8Encoding]::new($false))
+        $output = @(& (Join-Path $repositoryRoot 'Prompt-CcodRestart.ps1') -AppRoot $root -InstallRoot $root -Choice Restart 2>&1)
+        Assert-CcodEqual 0 $LASTEXITCODE 'restart choice exits successfully when the verified wrapper succeeds'
+        Assert-CcodTrue (Test-Path -LiteralPath $marker -PathType Leaf) 'restart choice invokes the wrapper'
+        Assert-CcodEqual 'True' ([IO.File]::ReadAllText($marker, [Text.UTF8Encoding]::new($false))) 'restart choice passes the explicit RestartCodex switch'
     } finally {
         if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
     }

--- a/tests/persistence/ManualWrappers.SelfTest.ps1
+++ b/tests/persistence/ManualWrappers.SelfTest.ps1
@@ -32,7 +32,7 @@ $root=Join-Path ([IO.Path]::GetTempPath()) ('ccod-wrapper-selftest-'+[guid]::New
 try{
     Invoke-CcodTest 'keeps exact public parameters and contains no process bridge or kill implementation' {
         $startAst=Get-CcodScriptAst $startPath;$resetAst=Get-CcodScriptAst $resetPath
-        Assert-CcodEqual 'RendererDebugPort,MainInspectorPort,TimeoutSeconds' (($startAst.ParamBlock.Parameters|ForEach-Object{$_.Name.VariablePath.UserPath}) -join ',') 'Start public parameters remain exact'
+        Assert-CcodEqual 'RendererDebugPort,MainInspectorPort,TimeoutSeconds,RestartCodex' (($startAst.ParamBlock.Parameters|ForEach-Object{$_.Name.VariablePath.UserPath}) -join ',') 'Start exposes an explicit installer-approved Codex restart option'
         Assert-CcodEqual 'BackupDeviceKeyStore,DoNotRestart' (($resetAst.ParamBlock.Parameters|ForEach-Object{$_.Name.VariablePath.UserPath}) -join ',') 'Reset public parameters remain exact'
         foreach($case in @(@{Name='Start';Ast=$startAst},@{Name='Reset';Ast=$resetAst})){
             $commands=@($case.Ast.FindAll({param($node)$node -is [Management.Automation.Language.CommandAst]},$true)|ForEach-Object{$_.GetCommandName()}|Where-Object{$_})
@@ -62,6 +62,12 @@ try{
 
         $arguments=New-CcodStartControllerArguments -Controller 'C:\installed\SessionController.ps1' -RequestPath 'C:\request.json' -ResultPath 'C:\result.json'
         Assert-CcodEqual '-NoProfile,-ExecutionPolicy,Bypass,-File,C:\installed\SessionController.ps1,-RequestPath,C:\request.json,-ResultPath,C:\result.json' ($arguments -join ',') 'child arguments carry only file paths, never Boolean text'
+
+        $restart=New-CcodRestartControllerRequest -RuntimeId 'runtime-1' -TimeoutSeconds 45 -SupervisorIdentity $identity -TransactionId 'ebd973bd-9b64-4cf3-a282-d080be72ff34'
+        Assert-CcodEqual 'Recover' $restart.action 'explicit restart first closes the verified current Codex session'
+        Assert-CcodEqual $true $restart.existingOnly 'explicit restart never adopts an unrelated closed-app session'
+        Assert-CcodEqual $false $restart.restartOrdinary 'explicit restart closes before the separate controlled relaunch'
+        Assert-CcodEqual 45000 $restart.timeoutMilliseconds 'explicit restart keeps its caller timeout'
     }
 
     Invoke-CcodTest 'real powershell file-mode children receive Boolean JSON without parameter binding failures' {
@@ -77,6 +83,11 @@ try{
         $resetRequest=New-CcodResetControllerRequest -RuntimeId 'runtime-1' -DoNotRestart $true -SupervisorIdentity $identity -TransactionId 'b56470ad-948a-4df7-b5f2-04a4df86a256'
         $reset=Invoke-CcodResetInstalledController -Resolved $resolved -Request $resetRequest
         Assert-CcodEqual $false $reset.source.restartOrdinary 'Reset DoNotRestart false crossed the real powershell.exe child as Boolean'
+
+        $restartRequest=New-CcodRestartControllerRequest -RuntimeId 'runtime-1' -TimeoutSeconds 45 -SupervisorIdentity $identity -TransactionId 'ebd973bd-9b64-4cf3-a282-d080be72ff34'
+        $restartWorkflow=Invoke-CcodRestartInstalledWorkflow -Resolved $resolved -RestartRequest $restartRequest -ApplyRequest $startRequest
+        Assert-CcodEqual 'Closed' $restartWorkflow.Close.outcome 'explicit restart closes the verified existing Codex session first'
+        Assert-CcodEqual 'Activated' $restartWorkflow.Apply.outcome 'explicit restart then starts the controlled Codex session'
     }
 
     Invoke-CcodTest 'keeps a successful reset successful when the optional device-key backup fails' {


### PR DESCRIPTION
## Fixes\n- stop the persistent prior supervisor before every upgrade, including when uninstall metadata is unavailable\n- replace environment-dependent source test execution during installation with structural payload validation\n- require the TrayHost payload before runtime activation\n- treat activation failure as an installation failure and do not show the restart prompt\n- make Restart now explicitly close the current Codex session then launch a new controlled session\n- keep silent upgrades non-blocking\n\n## Verification\n- Install lifecycle self-tests: 55/55\n- Manual wrapper tests: passed\n- Runtime, package, and TrayHost production smoke tests: passed\n- Local built installer: exit 0; active runtime and TrayHost verified at 2.4.20