### PR TITLE
Fix post-install Codex restart activation

### DIFF
--- a/Activate-CcodRemoteFix.ps1
+++ b/Activate-CcodRemoteFix.ps1
@@ -2,7 +2,8 @@
 param(
     [Parameter(Mandatory)][string]$AppRoot,
     [Parameter(Mandatory)][string]$InstallRoot,
-    [switch]$Prompt
+    [switch]$Prompt,
+    [switch]$NoUi
 )
 
 $ErrorActionPreference = 'Stop'
@@ -28,7 +29,7 @@ function Write-CcodActivationRecord {
 }
 
 function Show-CcodActivationFailure {
-    if (-not $Prompt) { return }
+    if (-not $Prompt -or $NoUi) { return }
     try {
         Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
         [Windows.Forms.MessageBox]::Show(
@@ -53,17 +54,28 @@ try {
     if ($LASTEXITCODE -ne 0) { throw 'CCOD_ACTIVATION_RUNTIME_FAILED' }
     Write-CcodActivationRecord -Code 'RUNTIME_ACTIVATED'
 
-    if ($Prompt) {
-        $promptScript = Join-Path $root 'Prompt-CcodRestart.ps1'
-        if (-not [IO.File]::Exists($promptScript)) { throw 'CCOD_ACTIVATION_PROMPT_SCRIPT_MISSING' }
-        $null = & $powershell -NoProfile -ExecutionPolicy Bypass -File $promptScript -AppRoot $root -InstallRoot $stateRoot 2>$null
-        if ($LASTEXITCODE -ne 0) { throw 'CCOD_ACTIVATION_RESTART_FAILED' }
-    }
-
-    Write-CcodActivationRecord -Code 'COMPLETED'
-    exit 0
 } catch {
     Write-CcodActivationRecord -Code 'FAILED'
     Show-CcodActivationFailure
     exit 1
 }
+
+if ($Prompt) {
+    $restartConfirmed = $false
+    try {
+        $promptScript = Join-Path $root 'Prompt-CcodRestart.ps1'
+        if ([IO.File]::Exists($promptScript)) {
+            $null = & $powershell -NoProfile -ExecutionPolicy Bypass -File $promptScript -AppRoot $root -InstallRoot $stateRoot 2>$null
+            $restartConfirmed = ($LASTEXITCODE -eq 0)
+        }
+    } catch {
+        $restartConfirmed = $false
+    }
+    if (-not $restartConfirmed) {
+        Write-CcodActivationRecord -Code 'RESTART_UNCONFIRMED'
+        exit 0
+    }
+}
+
+Write-CcodActivationRecord -Code 'COMPLETED'
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CodexRemote-fix release notes
 
-This file keeps the short bilingual summary for every published release.
+This file keeps the release record. GitHub Release bodies are generated from the English section only.
 
 ## Unreleased
 
@@ -16,6 +16,8 @@ No unreleased changes.
 - **Restart now** safely closes the current Codex session and launches a fresh controlled session after explicit confirmation.
 - Runtime activation runs in a background worker so the setup window remains responsive.
 - Tray language changes wait for native-host acknowledgement before completing.
+- Reissued the installer with a verified restart chain: recover a proven ordinary Codex session first, then activate the controlled session.
+- If restart confirmation fails after activation, the new runtime remains active and the event is recorded as `RESTART_UNCONFIRMED` rather than a false activation failure.
 
 ### 简体中文
 
@@ -25,6 +27,8 @@ No unreleased changes.
 - 只有明确选择“立即重启”后，才会安全关闭当前 Codex 并启动新的受控会话。
 - 运行时激活改由后台工作器执行，安装窗口可保持响应。
 - 托盘语言切换会等待原生宿主确认新快照后完成。
+- 重新发布安装包：重启链路会先恢复并确认普通 Codex 会话，再激活受控会话。
+- 如果激活完成后无法确认重启，新运行时仍保持已激活状态，并记录为 `RESTART_UNCONFIRMED`，不再误报激活失败。
 
 ## v2.4.19
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ supervisor are working.
 - Choosing **Restart now** safely closes the current Codex session and launches a fresh controlled session after explicit user confirmation.
 - Runtime activation now continues in a background worker, so the setup window can finish without freezing during the handoff.
 - Tray language changes wait for the native menu host to acknowledge the new presentation before returning.
+- The reissued installer verifies an ordinary Codex recovery before controlled activation, preventing a single-instance launch race.
+- If restart confirmation cannot be completed, the new runtime stays active and the user is asked to restart Codex manually instead of receiving a false activation-failure message.
 
 ## What's new in v2.4.19
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 - 只有用户明确选择“立即重启”后，才会安全关闭当前 Codex 并启动新的受控会话。
 - 运行时激活改为后台工作器执行，安装窗口可正常结束，不会在交接阶段卡死。
 - 托盘语言切换会等待原生菜单宿主确认新快照后才返回。
+- 重新发布的安装包会先验证普通 Codex 会话已经恢复，再进行受控激活，避免单实例启动竞争。
+- 如无法确认已重启，新 runtime 仍保持激活状态，并提示用户手动重启 Codex，不再误报激活失败。
 
 ## v2.4.19 更新内容
 
@@ -108,7 +110,7 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 为 2.4.20 发布提供可直接运行的 `CodexRemote-fix-2.4.20-setup.exe`
 及 `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`。
 
-每次发布都会在本 README 和 GitHub Release 正文中追加简短的中英文更新说明。
+GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。
 
 Codex Desktop 更新后，请到 [Releases](https://github.com/naipi11/CodexRemote-fix/releases)

--- a/Start-CodexControlOtherDevices.ps1
+++ b/Start-CodexControlOtherDevices.ps1
@@ -20,9 +20,8 @@ function Resolve-CcodStartInstalledController {
     $validation=Test-CcodRuntimeManifest -RuntimeDirectory $runtime -ExpectedRuntimeId $active.activeRuntime
     if(-not $validation.Valid){throw "Installed runtime validation failed: $($validation.Code). Repair or reinstall CodexRemote-fix."}
     $controller=Join-Path $runtime 'src\persistence\SessionController.ps1'
-    $processControl=Join-Path $runtime 'src\persistence\modules\ProcessControl.psm1'
-    if(-not (Test-Path -LiteralPath $controller -PathType Leaf) -or -not (Test-Path -LiteralPath $processControl -PathType Leaf)){throw 'The verified active runtime does not contain the required restart files. Repair or reinstall.'}
-    [pscustomobject]@{RuntimeId=$active.activeRuntime;RuntimeRoot=$runtime;Controller=[IO.Path]::GetFullPath($controller);ProcessControl=[IO.Path]::GetFullPath($processControl)}
+    if(-not (Test-Path -LiteralPath $controller -PathType Leaf)){throw 'The verified active runtime does not contain the required restart files. Repair or reinstall.'}
+    [pscustomobject]@{RuntimeId=$active.activeRuntime;RuntimeRoot=$runtime;Controller=[IO.Path]::GetFullPath($controller)}
 }
 
 function Get-CcodStartSupervisorIdentity {
@@ -44,7 +43,7 @@ function New-CcodRestartControllerRequest {
     param([string]$RuntimeId,[int]$TimeoutSeconds,$SupervisorIdentity=(Get-CcodStartSupervisorIdentity),[string]$TransactionId=([guid]::NewGuid().ToString('D')))
     [pscustomobject][ordered]@{
         schemaVersion=1;action='Recover';transactionId=$TransactionId;runtimeId=$RuntimeId;supervisorIdentity=$SupervisorIdentity;source=$null;existingOnly=$true
-        rendererPort=$null;mainPort=$null;timeoutMilliseconds=[int]($TimeoutSeconds*1000);restartOrdinary=$false
+        rendererPort=$null;mainPort=$null;timeoutMilliseconds=[int]($TimeoutSeconds*1000);restartOrdinary=$true
     }
 }
 
@@ -75,58 +74,24 @@ function Invoke-CcodStartInstalledController {
     }
 }
 
-function Start-CcodRestartOrdinary {
-    param($Resolved)
-    Import-Module $Resolved.ProcessControl -Force
-    return Start-CcodProcess -Mode Ordinary
-}
-
-function Wait-CcodRestartActivation {
-    param([string]$InstallRoot,[string]$RuntimeId,[int]$TimeoutSeconds,[AllowNull()][int]$PreviousPid)
-    $statusPath=Join-Path $InstallRoot 'state\status.json'
-    $deadline=[DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-    while([DateTime]::UtcNow -lt $deadline){
-        try{
-            if([IO.File]::Exists($statusPath)){
-                $status=Get-Content -LiteralPath $statusPath -Raw|ConvertFrom-Json -ErrorAction Stop
-                $session=$status.session
-                if($null -ne $session -and $session.runtimeId -ceq $RuntimeId -and $session.sessionState -ceq 'Active' -and
-                   $null -ne $session.codex -and ($session.codex.pid -is [int] -or $session.codex.pid -is [long]) -and ($null -eq $PreviousPid -or $session.codex.pid -ne $PreviousPid)){return $true}
-            }
-        }catch{}
-        Start-Sleep -Milliseconds 200
-    }
-    return $false
-}
-
 function Invoke-CcodRestartInstalledWorkflow {
-    param(
-        $Resolved,
-        $RestartRequest,
-        [string]$InstallRoot,
-        [int]$TimeoutSeconds,
-        [scriptblock]$StartOrdinary={param($ResolvedValue)Start-CcodRestartOrdinary -Resolved $ResolvedValue},
-        [scriptblock]$WaitForActive={param($Root,$RuntimeId,$Seconds,$PreviousPid)Wait-CcodRestartActivation -InstallRoot $Root -RuntimeId $RuntimeId -TimeoutSeconds $Seconds -PreviousPid $PreviousPid}
-    )
-    $close=Invoke-CcodStartInstalledController -Resolved $Resolved -Request $RestartRequest
-    if($close.outcome -notin @('Closed','NoAction')){throw "Codex restart could not safely close the current session: $($close.outcome)"}
-    $previousPid=$null
-    if($null -ne $close.special -and $close.special.PSObject.Properties['pid'] -and $close.special.pid -is [int]){$previousPid=[int]$close.special.pid}
-    $start=& $StartOrdinary $Resolved
-    if($null -eq $start -or $start.Outcome -notin @('Started','Adopted')){throw 'Codex restart could not launch an ordinary Codex session.'}
-    if(-not (& $WaitForActive $InstallRoot $Resolved.RuntimeId $TimeoutSeconds $previousPid)){throw 'Codex restarted, but CodexRemote-fix did not confirm the new controlled session in time.'}
-    return [pscustomobject][ordered]@{Close=$close;Start=$start}
+    param($Resolved,$RestartRequest,$ApplyRequest)
+    $recovery=Invoke-CcodStartInstalledController -Resolved $Resolved -Request $RestartRequest
+    if($recovery.outcome -notin @('Recovered','NoAction','Closed')){throw "Codex restart could not safely recover the current session: $($recovery.outcome)"}
+    $apply=Invoke-CcodStartInstalledController -Resolved $Resolved -Request $ApplyRequest
+    if($apply.outcome -notin @('Activated','NoAction')){throw "Codex restart did not activate the controlled session: $($apply.outcome)"}
+    return [pscustomobject][ordered]@{Recovery=$recovery;Apply=$apply}
 }
 
 if($MyInvocation.InvocationName -ne '.'){
     $installRoot=[IO.Path]::GetFullPath((Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'CodexControlOtherDevices'))
     $resolved=Resolve-CcodStartInstalledController -InstallRoot $installRoot
+    $request=New-CcodStartControllerRequest -RuntimeId $resolved.RuntimeId -RendererDebugPort $RendererDebugPort -MainInspectorPort $MainInspectorPort -TimeoutSeconds $TimeoutSeconds
     if($RestartCodex){
         $restart=New-CcodRestartControllerRequest -RuntimeId $resolved.RuntimeId -TimeoutSeconds $TimeoutSeconds
-        $workflow=Invoke-CcodRestartInstalledWorkflow -Resolved $resolved -RestartRequest $restart -InstallRoot $installRoot -TimeoutSeconds $TimeoutSeconds
-        $result=$workflow.Start
+        $workflow=Invoke-CcodRestartInstalledWorkflow -Resolved $resolved -RestartRequest $restart -ApplyRequest $request
+        $result=$workflow.Apply
     }else{
-        $request=New-CcodStartControllerRequest -RuntimeId $resolved.RuntimeId -RendererDebugPort $RendererDebugPort -MainInspectorPort $MainInspectorPort -TimeoutSeconds $TimeoutSeconds
         $result=Invoke-CcodStartInstalledController -Resolved $resolved -Request $request
     }
     Write-Host ''

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1198,6 +1198,27 @@ $results += Invoke-CcodTest 'activation worker installs first and prompts only a
     }
 }
 
+$results += Invoke-CcodTest 'activation worker preserves an activated runtime when optional restart confirmation fails' {
+    $root = Join-Path ([IO.Path]::GetTempPath()) ('ccod-activation-restart-warning-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [IO.Directory]::CreateDirectory($root) | Out-Null
+        $marker = Join-Path $root 'marker.txt'
+        $installScript = Join-Path $root 'Install-CodexControlOtherDevices.ps1'
+        $promptScript = Join-Path $root 'Prompt-CcodRestart.ps1'
+        [IO.File]::WriteAllText($installScript, "[IO.File]::AppendAllText('$marker','install,',[Text.UTF8Encoding]::new(`$false)); exit 0", [Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllText($promptScript, "param([string]`$AppRoot,[string]`$InstallRoot);[IO.File]::AppendAllText('$marker','prompt',[Text.UTF8Encoding]::new(`$false)); exit 1", [Text.UTF8Encoding]::new($false))
+        $output = @(& (Join-Path $repositoryRoot 'Activate-CcodRemoteFix.ps1') -AppRoot $root -InstallRoot $root -Prompt -NoUi 2>&1)
+        Assert-CcodEqual 0 $LASTEXITCODE 'restart confirmation failure does not invalidate a completed runtime activation'
+        Assert-CcodEqual 'install,prompt' ([IO.File]::ReadAllText($marker, [Text.UTF8Encoding]::new($false))) 'restart is attempted only after activation succeeds'
+        $activationLog = Get-Content -LiteralPath (Join-Path $root 'logs\post-install-activation.log') -Raw
+        Assert-CcodTrue ($activationLog -match '"code":"RUNTIME_ACTIVATED"') 'activation log preserves the completed runtime activation record'
+        Assert-CcodTrue ($activationLog -match '"code":"RESTART_UNCONFIRMED"') 'activation log records restart confirmation separately'
+        Assert-CcodTrue ($activationLog -notmatch '"code":"FAILED"') 'restart confirmation failure is not mislabeled as runtime activation failure'
+    } finally {
+        if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}
+
 $results += Invoke-CcodTest 'post-install restart prompt requests an explicit controlled Codex restart after Yes' {
     $root = Join-Path ([IO.Path]::GetTempPath()) ('ccod-restart-prompt-yes-' + [guid]::NewGuid().ToString('N'))
     try {

--- a/tests/persistence/ManualWrappers.SelfTest.ps1
+++ b/tests/persistence/ManualWrappers.SelfTest.ps1
@@ -66,7 +66,7 @@ try{
         $restart=New-CcodRestartControllerRequest -RuntimeId 'runtime-1' -TimeoutSeconds 45 -SupervisorIdentity $identity -TransactionId 'ebd973bd-9b64-4cf3-a282-d080be72ff34'
         Assert-CcodEqual 'Recover' $restart.action 'explicit restart first closes the verified current Codex session'
         Assert-CcodEqual $true $restart.existingOnly 'explicit restart never adopts an unrelated closed-app session'
-        Assert-CcodEqual $false $restart.restartOrdinary 'explicit restart closes before the separate controlled relaunch'
+        Assert-CcodEqual $true $restart.restartOrdinary 'explicit restart uses the verified recovery path before controlled reactivation'
         Assert-CcodEqual 45000 $restart.timeoutMilliseconds 'explicit restart keeps its caller timeout'
     }
 
@@ -85,14 +85,9 @@ try{
         Assert-CcodEqual $false $reset.source.restartOrdinary 'Reset DoNotRestart false crossed the real powershell.exe child as Boolean'
 
         $restartRequest=New-CcodRestartControllerRequest -RuntimeId 'runtime-1' -TimeoutSeconds 45 -SupervisorIdentity $identity -TransactionId 'ebd973bd-9b64-4cf3-a282-d080be72ff34'
-        $restartStarts=[Collections.Generic.List[string]]::new();$restartWaits=[Collections.Generic.List[string]]::new()
-        $restartWorkflow=Invoke-CcodRestartInstalledWorkflow -Resolved $resolved -RestartRequest $restartRequest -InstallRoot $root -TimeoutSeconds 45 `
-            -StartOrdinary {param($ResolvedValue)$restartStarts.Add($ResolvedValue.RuntimeId);[pscustomobject]@{Outcome='Started';Snapshot=$null;Process=$null}}.GetNewClosure() `
-            -WaitForActive {param($InstallRoot,$RuntimeId,$TimeoutSeconds,$PreviousPid)$restartWaits.Add("$RuntimeId|$TimeoutSeconds|$PreviousPid");$true}.GetNewClosure()
-        Assert-CcodEqual 'Closed' $restartWorkflow.Close.outcome 'explicit restart closes the verified existing Codex session first'
-        Assert-CcodEqual 'Started' $restartWorkflow.Start.Outcome 'explicit restart launches one ordinary Codex instance for the supervisor to take over'
-        Assert-CcodEqual 'runtime-1' ($restartStarts -join ',') 'explicit restart starts the verified active runtime package exactly once'
-        Assert-CcodEqual 'runtime-1|45|' ($restartWaits -join ',') 'explicit restart waits for the supervisor to confirm the new controlled session'
+        $restartWorkflow=Invoke-CcodRestartInstalledWorkflow -Resolved $resolved -RestartRequest $restartRequest -ApplyRequest $startRequest
+        Assert-CcodEqual 'Recovered' $restartWorkflow.Recovery.outcome 'explicit restart proves an ordinary recovery before reactivation'
+        Assert-CcodEqual 'Activated' $restartWorkflow.Apply.outcome 'explicit restart reactivates the controlled Codex session through the verified controller'
     }
 
     Invoke-CcodTest 'keeps a successful reset successful when the optional device-key backup fails' {
@@ -118,15 +113,15 @@ try{
     }
 
     Invoke-CcodTest 'dispatches only to a manifest-verified active runtime' {
-        $installRoot=Join-Path $root 'installed';$staging=Join-Path $installRoot 'staging';$controller=Join-Path $staging 'src\persistence\SessionController.ps1';$stateModule=Join-Path $staging 'src\persistence\modules\StateStore.psm1';$processModule=Join-Path $staging 'src\persistence\modules\ProcessControl.psm1'
+        $installRoot=Join-Path $root 'installed';$staging=Join-Path $installRoot 'staging';$controller=Join-Path $staging 'src\persistence\SessionController.ps1';$stateModule=Join-Path $staging 'src\persistence\modules\StateStore.psm1'
         [IO.Directory]::CreateDirectory((Split-Path $controller -Parent))|Out-Null;[IO.Directory]::CreateDirectory((Split-Path $stateModule -Parent))|Out-Null
-        [IO.File]::WriteAllText($controller,'# installed controller',[Text.UTF8Encoding]::new($false));[IO.File]::WriteAllText($stateModule,'# installed state',[Text.UTF8Encoding]::new($false));[IO.File]::WriteAllText($processModule,'# installed process control',[Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllText($controller,'# installed controller',[Text.UTF8Encoding]::new($false));[IO.File]::WriteAllText($stateModule,'# installed state',[Text.UTF8Encoding]::new($false))
         $manifest=New-CcodRuntimeManifest -RuntimeDirectory $staging -ProjectVersion '2.0.0';$runtime=Join-Path (Join-Path $installRoot 'runtime') $manifest.runtimeId;[IO.Directory]::CreateDirectory((Split-Path $runtime -Parent))|Out-Null;[IO.Directory]::Move($staging,$runtime)
         Write-CcodAtomicJson -Path (Join-Path $runtime 'manifest.json') -Value $manifest;Set-CcodActiveRuntime -InstallRoot $installRoot -NewRuntimeId $manifest.runtimeId|Out-Null
         $start=Resolve-CcodStartInstalledController -InstallRoot $installRoot;$reset=Resolve-CcodResetInstalledController -InstallRoot $installRoot
         Assert-CcodEqual ([IO.Path]::GetFullPath((Join-Path $runtime 'src\persistence\SessionController.ps1'))) $start.Controller 'Start targets verified active controller'
         Assert-CcodEqual $start.Controller $reset.Controller 'Reset targets the same verified runtime'
-        Assert-CcodEqual ([IO.Path]::GetFullPath((Join-Path $runtime 'src\persistence\modules\ProcessControl.psm1'))) $start.ProcessControl 'Start targets verified active process control'
+        Assert-CcodEqual $null $start.PSObject.Properties['ProcessControl'] 'Start uses only the verified controller and cannot bypass its recovery protocol'
         [IO.File]::AppendAllText($start.Controller,'tampered',[Text.UTF8Encoding]::new($false))
         Assert-CcodThrows {Resolve-CcodStartInstalledController -InstallRoot $installRoot} '*'
     }


### PR DESCRIPTION
Summary: replace the false-positive direct launch path with verified recovery followed by controlled activation; preserve an activated runtime when restart confirmation fails; update v2.4.20 documentation. Verification: npm test, npm run test:runtime, npm run test:package, and build/build.ps1 -Version 2.4.20.