### PR TITLE
Fix TrayHost parent-reader shutdown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.4.21
+
+### English
+
+- Fixed a TrayHost parent-reader disposal race that could terminate the persistent supervisor after the remote-control session had already become active.
+- The parent now waits for TrayHost reader, writer, and stderr threads to leave their pipe operations before disposing synchronization handles.
+- Added a native regression test for a remote-fault shutdown race, preventing the `System.ObjectDisposedException` observed in the parent reader.
+
+### 简体中文
+
+- 修复 TrayHost 父端读取线程的释放竞态：远程控制会话已生效后，持久 Supervisor 不会再因该竞态退出。
+- 父端现在会等待 TrayHost 的读取、写入和 stderr 线程退出管道操作后，才释放同步句柄。
+- 新增原生回归测试，覆盖远端故障与关闭并发场景，防止 ParentReader 出现 `System.ObjectDisposedException`。
+
 ## v2.4.20
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.4.20-setup.exe` and `CodexRemote-fix-2.4.20-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.4.20-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.4.21-setup.exe` and `CodexRemote-fix-2.4.21-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.4.21-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. When the tray icon is green, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,12 @@ needed after upgrading.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.4.21
+
+- Fixed a TrayHost parent-reader disposal race that could make the tray icon disappear while the controlled Codex session remained active.
+- TrayHost shutdown now waits for its background pipe threads before releasing synchronization handles.
+- Added a native regression test for the remote-fault disposal race.
 
 ## What's new in v2.4.20
 
@@ -114,8 +120,8 @@ supervisor are working.
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.4.20 release includes the ready-to-run `CodexRemote-fix-2.4.20-setup.exe`
-and `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`.
+so the 2.4.21 release includes the ready-to-run `CodexRemote-fix-2.4.21-setup.exe`
+and `CodexRemote-fix-2.4.21-setup.exe.sha256.txt`.
 
 Each release appends a short English change summary to the GitHub release body. The README and
 [CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.20-setup.exe` 和 `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.4.20-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.21-setup.exe` 和 `CodexRemote-fix-2.4.21-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.4.21-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。托盘图标为绿色时，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.4.21 更新内容
+
+- 修复 TrayHost 父端读取线程的释放竞态：即使受控 Codex 会话已正常运行，托盘图标也不会再因此消失。
+- TrayHost 关闭时会先等待后台管道线程退出，再释放同步句柄。
+- 新增原生回归测试，覆盖远端故障与资源释放并发场景。
 
 ## v2.4.20 更新内容
 
@@ -107,8 +113,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
 `.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此后续每次更新都会
-为 2.4.20 发布提供可直接运行的 `CodexRemote-fix-2.4.20-setup.exe`
-及 `CodexRemote-fix-2.4.20-setup.exe.sha256.txt`。
+为 2.4.21 发布提供可直接运行的 `CodexRemote-fix-2.4.21-setup.exe`
+及 `CodexRemote-fix-2.4.21-setup.exe.sha256.txt`。
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.4.20",
+  "version": "2.4.21",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/trayhost/TrayHostParentClient.cs
+++ b/src/trayhost/TrayHostParentClient.cs
@@ -27,6 +27,8 @@ public sealed class TrayHostStartReceipt
 public sealed class TrayHostParentClient : IDisposable
 {
     internal static Func<ProcessStartInfo, Process> TestProcessFactory = null;
+    internal static Action TestBeforeReaderStopSignal = null;
+    internal static Action TestBeforeWaitHandleDispose = null;
 
     private readonly object _eventGate = new object();
     private readonly object _writeGate = new object();
@@ -42,8 +44,9 @@ public sealed class TrayHostParentClient : IDisposable
     private SessionKeys _keys;
     private ulong _writeSequence;
     private ulong _readSequence;
-    private bool _shutdownRequested;
-    private bool _disposed;
+    private volatile bool _shutdownRequested;
+    private int _disposeGate;
+    private int _disposed;
     private Thread _writerThread;
     private Thread _readerThread;
     private Thread _stderrThread;
@@ -109,8 +112,8 @@ public sealed class TrayHostParentClient : IDisposable
 
     public bool TryPublish(PresentationSnapshot snapshot)
     {
-        if (_disposed || snapshot == null || _transport.GetHealth() != TrayHostHealth.Ready) { return false; }
-        bool accepted = _transport.TrySetLatestPresentation(snapshot); if (accepted) { _work.Set(); } return accepted;
+        if (IsClosing() || snapshot == null || _transport.GetHealth() != TrayHostHealth.Ready) { return false; }
+        bool accepted = _transport.TrySetLatestPresentation(snapshot); if (accepted) { SignalWork(); } return accepted;
     }
 
     public bool TryDequeueEvent(out TrayHostEvent value)
@@ -120,25 +123,31 @@ public sealed class TrayHostParentClient : IDisposable
 
     public bool BeginShutdown(ShutdownReason reason, ulong finalRevision)
     {
-        if (_disposed || _shutdownRequested) { return false; }
-        _shutdownRequested = true; _transport.MarkStopping();
-        bool accepted = _transport.TryEnqueueControl(new TrayHostControl(TrayHostControlKind.Shutdown, reason, finalRevision));
-        if (accepted) { _work.Set(); } return accepted;
+        if (IsClosing()) { return false; }
+        return BeginShutdownCore(reason, finalRevision);
     }
 
-    public bool WaitForStopped(TimeSpan timeout) { return _stopped.WaitOne(timeout); }
-    public bool WaitForActivity(TimeSpan timeout) { return _work.WaitOne(timeout); }
+    private bool BeginShutdownCore(ShutdownReason reason, ulong finalRevision)
+    {
+        if (_shutdownRequested || _transport == null || _transport.GetHealth() != TrayHostHealth.Ready) { return false; }
+        _shutdownRequested = true; _transport.MarkStopping();
+        bool accepted = _transport.TryEnqueueControl(new TrayHostControl(TrayHostControlKind.Shutdown, reason, finalRevision));
+        if (accepted) { SignalWork(); } return accepted;
+    }
+
+    public bool WaitForStopped(TimeSpan timeout) { try { return _stopped.WaitOne(timeout); } catch (ObjectDisposedException) { return true; } }
+    public bool WaitForActivity(TimeSpan timeout) { if (IsDisposing()) { return false; } try { return _work.WaitOne(timeout); } catch (ObjectDisposedException) { return false; } }
     public TrayHostHealth GetHealth() { return _transport == null ? TrayHostHealth.Stopped : _transport.GetHealth(); }
 
     private void WriterLoop()
     {
         try
         {
-            while (!_disposed)
+            while (!IsDisposing())
             {
                 _work.WaitOne(250);
                 TrayHostOutbound outbound;
-                while (!_disposed && _transport.TryDequeueOutbound(out outbound))
+                while (!IsDisposing() && _transport.TryDequeueOutbound(out outbound))
                 {
                     if (outbound.Kind == TrayHostOutboundKind.Presentation) { WriteAuthenticated(TrayHostMessageType.Presentation, TrayHostWire.WritePresentation(outbound.Presentation)); }
                     else if (outbound.Kind == TrayHostOutboundKind.Action) { WriteAuthenticated(TrayHostMessageType.Action, TrayHostWire.WriteAction(outbound.Action)); }
@@ -146,7 +155,7 @@ public sealed class TrayHostParentClient : IDisposable
                 }
             }
         }
-        catch (Exception error) { HandleTransportFailure(error); }
+        catch (Exception error) { if (IsDisposing() || _shutdownRequested) { SignalStopped(); } else { HandleTransportFailure(error); } }
     }
 
     private void WriteControl(TrayHostControl control)
@@ -159,17 +168,22 @@ public sealed class TrayHostParentClient : IDisposable
     {
         try
         {
-            while (!_disposed)
+            while (!IsDisposing())
             {
                 ProtocolFrame frame = ReadAuthenticated();
                 if (frame.MessageType == TrayHostMessageType.PresentationAck) { EnqueueEvent(TrayHostEvent.Ack(TrayHostWire.ReadRevision(frame.Payload))); }
                 else if (frame.MessageType == TrayHostMessageType.Action) { EnqueueEvent(TrayHostEvent.Action(TrayHostWire.ReadAction(frame.Payload))); }
-                else if (frame.MessageType == TrayHostMessageType.ShutdownAck) { EnqueueEvent(TrayHostEvent.Exited()); _transport.Dispose(); _stopped.Set(); return; }
+                else if (frame.MessageType == TrayHostMessageType.ShutdownAck) { EnqueueEvent(TrayHostEvent.Exited()); _transport.Dispose(); SignalStopped(); return; }
                 else if (frame.MessageType == TrayHostMessageType.Fault) { EnqueueEvent(TrayHostEvent.Fault("CCOD_TRAYHOST_REMOTE_FAULT")); }
                 else if (frame.MessageType == TrayHostMessageType.Pong) { _work.Set(); }
             }
         }
-        catch (Exception error) { if (!_shutdownRequested) { HandleTransportFailure(error); } else { _stopped.Set(); } }
+        catch (Exception error)
+        {
+            if (IsDisposing()) { InvokeTestHook(TestBeforeReaderStopSignal); SignalStopped(); }
+            else if (!_shutdownRequested) { HandleTransportFailure(error); }
+            else { SignalStopped(); }
+        }
     }
 
     private void StderrLoop()
@@ -177,7 +191,7 @@ public sealed class TrayHostParentClient : IDisposable
         try
         {
             byte[] buffer = new byte[1024]; int read;
-            while (!_disposed && (read = _childError.Read(buffer, 0, buffer.Length)) > 0) { byte[] copy = new byte[read]; Buffer.BlockCopy(buffer, 0, copy, 0, read); _transport.RecordStderr(copy); }
+            while (!IsDisposing() && (read = _childError.Read(buffer, 0, buffer.Length)) > 0) { byte[] copy = new byte[read]; Buffer.BlockCopy(buffer, 0, copy, 0, read); _transport.RecordStderr(copy); }
         }
         catch { }
     }
@@ -195,8 +209,29 @@ public sealed class TrayHostParentClient : IDisposable
         return ProtocolCodec.ReadAuthenticated(_childOutput, ProtocolDirection.HostToParent, _keys.HostEpoch, _readSequence++, _keys.HostToParent);
     }
 
-    private void EnqueueEvent(TrayHostEvent value) { lock (_eventGate) { if (_events.Count < 32) { _events.Enqueue(value); } } _work.Set(); }
-    private void HandleTransportFailure(Exception error) { _transport.MarkPipeBroken("CCOD_TRAYHOST_TRANSPORT_FAILED"); EnqueueEvent(TrayHostEvent.Fault("CCOD_TRAYHOST_TRANSPORT_FAILED")); _stopped.Set(); }
+    private bool IsDisposing() { return Volatile.Read(ref _disposed) != 0; }
+    private bool IsClosing() { return Volatile.Read(ref _disposeGate) != 0; }
+    private void SignalWork() { try { _work.Set(); } catch (ObjectDisposedException) { } }
+    private void SignalStopped() { try { _stopped.Set(); } catch (ObjectDisposedException) { } }
+    private static void InvokeTestHook(Action hook) { if (hook != null) { hook(); } }
+    private void EnqueueEvent(TrayHostEvent value) { lock (_eventGate) { if (_events.Count < 32) { _events.Enqueue(value); } } SignalWork(); }
+    private void HandleTransportFailure(Exception error)
+    {
+        if (IsDisposing()) { SignalStopped(); return; }
+        _transport.MarkPipeBroken("CCOD_TRAYHOST_TRANSPORT_FAILED"); EnqueueEvent(TrayHostEvent.Fault("CCOD_TRAYHOST_TRANSPORT_FAILED")); SignalStopped();
+    }
+
+    private bool JoinBackgroundThreads(TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow.Add(timeout); bool complete = true;
+        foreach (Thread thread in new Thread[] { _writerThread, _readerThread, _stderrThread })
+        {
+            if (thread == null || thread == Thread.CurrentThread || !thread.IsAlive) { continue; }
+            int remaining = (int)Math.Max(0, (deadline - DateTime.UtcNow).TotalMilliseconds);
+            if (remaining == 0 || !thread.Join(remaining)) { complete = false; }
+        }
+        return complete;
+    }
 
     private static void ValidateOptions(TrayHostStartOptions options)
     {
@@ -205,18 +240,24 @@ public sealed class TrayHostParentClient : IDisposable
 
     public void Dispose()
     {
-        if (_disposed) { return; }
-        if (!_shutdownRequested && _transport != null && _transport.GetHealth() == TrayHostHealth.Ready) { BeginShutdown(ShutdownReason.ParentFault, 1UL); }
+        if (Interlocked.CompareExchange(ref _disposeGate, 1, 0) != 0) { return; }
+        if (!_shutdownRequested && _transport != null && _transport.GetHealth() == TrayHostHealth.Ready) { BeginShutdownCore(ShutdownReason.ParentFault, 1UL); }
         if (_shutdownRequested) { _stopped.WaitOne(TimeSpan.FromSeconds(2)); }
-        _disposed = true; _work.Set();
+        Interlocked.Exchange(ref _disposed, 1);
+        SignalWork();
         try { if (_job != null) { _job.Terminate(1U); } } catch { }
         try { if (_childInput != null) { _childInput.Close(); } } catch { }
         try { if (_childOutput != null) { _childOutput.Close(); } } catch { }
         try { if (_childError != null) { _childError.Close(); } } catch { }
         try { if (_process != null && !_process.HasExited) { _process.WaitForExit(2000); } } catch { }
+        bool workersStopped = JoinBackgroundThreads(TimeSpan.FromSeconds(2));
         try { if (_job != null) { _job.Dispose(); } } catch { }
         try { if (_process != null) { _process.Dispose(); } } catch { }
         if (_transport != null) { _transport.Dispose(); }
-        _work.Dispose(); _stopped.Dispose();
+        if (workersStopped)
+        {
+            InvokeTestHook(TestBeforeWaitHandleDispose);
+            _work.Dispose(); _stopped.Dispose();
+        }
     }
 }

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1131,19 +1131,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.20 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.21 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.4.20' ([string]$package.version) 'package version is exactly 2.4.20'
+    Assert-CcodEqual '2.4.21' ([string]$package.version) 'package version is exactly 2.4.21'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.4.20-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.21-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.4.20-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.21-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 $results += Invoke-CcodTest 'installer stops the running supervisor before replacing the installed version' {
@@ -1330,16 +1330,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.20-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/trayhost/TrayHostParentClientSelfTest.cs
+++ b/tests/trayhost/TrayHostParentClientSelfTest.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Threading;
 
 internal static class TrayHostParentClientSelfTest
 {
+    private static string PeerArguments = "--peer";
+
     private static void AssertTrue(bool value, string message) { if (!value) { throw new InvalidOperationException(message); } }
 
     private static PresentationSnapshot Snapshot(ulong revision)
@@ -17,7 +20,7 @@ internal static class TrayHostParentClientSelfTest
 
     private static Process StartPeer(ProcessStartInfo requested)
     {
-        requested.Arguments = "--peer";
+        requested.Arguments = PeerArguments;
         requested.UseShellExecute = false;
         requested.CreateNoWindow = true;
         requested.RedirectStandardInput = true;
@@ -26,7 +29,7 @@ internal static class TrayHostParentClientSelfTest
         return Process.Start(requested);
     }
 
-    private static void RunPeer()
+    private static void RunPeer(bool emitFaultAndIgnoreShutdown)
     {
         Stream input = Console.OpenStandardInput();
         Stream output = Console.OpenStandardOutput();
@@ -42,24 +45,101 @@ internal static class TrayHostParentClientSelfTest
         AssertTrue(presentation.MessageType == TrayHostMessageType.Presentation, "peer receives initial presentation");
         ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.PresentationAck, epoch, 1UL, TrayHostWire.WriteRevision(TrayHostWire.ReadPresentation(presentation.Payload).Revision)), keys.HostToParent);
         ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.UiReady, epoch, 2UL, TrayHostWire.WriteRevision(TrayHostWire.ReadPresentation(presentation.Payload).Revision)), keys.HostToParent);
-        ulong sequence = 3UL;
+        ulong inboundSequence = 2UL;
+        ulong outboundSequence = 3UL;
+        if (emitFaultAndIgnoreShutdown)
+        {
+            ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.Fault, epoch, outboundSequence++, new byte[0]), keys.HostToParent);
+        }
         while (true)
         {
-            ProtocolFrame frame = ProtocolCodec.ReadAuthenticated(input, ProtocolDirection.ParentToHost, epoch, sequence - 1UL, keys.ParentToHost);
+            ProtocolFrame frame = ProtocolCodec.ReadAuthenticated(input, ProtocolDirection.ParentToHost, epoch, inboundSequence++, keys.ParentToHost);
             if (frame.MessageType == TrayHostMessageType.Shutdown)
             {
-                ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.ShutdownAck, epoch, sequence, frame.Payload), keys.HostToParent);
+                if (emitFaultAndIgnoreShutdown) { Thread.Sleep(Timeout.Infinite); }
+                ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.ShutdownAck, epoch, outboundSequence++, frame.Payload), keys.HostToParent);
                 return;
             }
             if (frame.MessageType == TrayHostMessageType.Presentation)
             {
-                ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.PresentationAck, epoch, sequence, TrayHostWire.WriteRevision(TrayHostWire.ReadPresentation(frame.Payload).Revision)), keys.HostToParent);
+                ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.PresentationAck, epoch, outboundSequence++, TrayHostWire.WriteRevision(TrayHostWire.ReadPresentation(frame.Payload).Revision)), keys.HostToParent);
             }
             else if (frame.MessageType == TrayHostMessageType.Ping)
             {
-                ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.Pong, epoch, sequence, frame.Payload), keys.HostToParent);
+                ProtocolCodec.WriteAuthenticated(output, ProtocolFrame.Authenticated(ProtocolDirection.HostToParent, TrayHostMessageType.Pong, epoch, outboundSequence++, frame.Payload), keys.HostToParent);
             }
-            sequence++;
+        }
+    }
+
+    private static TrayHostStartOptions Options()
+    {
+        Process current = Process.GetCurrentProcess();
+        return new TrayHostStartOptions {
+            ExePath = current.MainModule.FileName,
+            RuntimeId = "test-runtime",
+            ParentPid = current.Id,
+            ParentCreationFileTimeUtc = current.StartTime.ToFileTimeUtc(),
+            InitialPresentation = Snapshot(1UL)
+        };
+    }
+
+    private static void TestDisposeRequestsGracefulShutdown()
+    {
+        PeerArguments = "--peer";
+        TrayHostParentClient client = TrayHostParentClient.Start(Options());
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        client.Dispose();
+        stopwatch.Stop();
+        AssertTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(1), "Dispose sends a graceful shutdown before tearing down the tray host transport");
+    }
+
+    private static void TestDisposeAfterRemoteFaultDoesNotCrashParentReader()
+    {
+        PeerArguments = "--fault-peer";
+        FieldInfo readerHook = typeof(TrayHostParentClient).GetField("TestBeforeReaderStopSignal", BindingFlags.Static | BindingFlags.NonPublic);
+        FieldInfo waitHandleDisposeHook = typeof(TrayHostParentClient).GetField("TestBeforeWaitHandleDispose", BindingFlags.Static | BindingFlags.NonPublic);
+        AssertTrue(readerHook != null && waitHandleDisposeHook != null, "parent client exposes the disposal-race synchronization hooks");
+        ManualResetEvent readerBlocked = new ManualResetEvent(false);
+        ManualResetEvent releaseReader = new ManualResetEvent(false);
+        ManualResetEvent waitHandleDisposeStarted = new ManualResetEvent(false);
+        TrayHostParentClient client = null;
+        Thread disposer = null;
+        Exception disposeError = null;
+        try
+        {
+            readerHook.SetValue(null, (Action)delegate { readerBlocked.Set(); releaseReader.WaitOne(TimeSpan.FromSeconds(3)); });
+            waitHandleDisposeHook.SetValue(null, (Action)delegate { waitHandleDisposeStarted.Set(); });
+            client = TrayHostParentClient.Start(Options());
+            bool faultReceived = false;
+            DateTime deadline = DateTime.UtcNow.AddSeconds(2);
+            while (!faultReceived && DateTime.UtcNow < deadline)
+            {
+                client.WaitForActivity(TimeSpan.FromMilliseconds(100));
+                TrayHostEvent value;
+                while (client.TryDequeueEvent(out value)) { if (value.Kind == TrayHostEventKind.Fault) { faultReceived = true; } }
+            }
+            AssertTrue(faultReceived, "fault peer reaches the parent reader before disposal");
+            TrayHostParentClient closingClient = client;
+            disposer = new Thread((ThreadStart)delegate { try { closingClient.Dispose(); } catch (Exception error) { disposeError = error; } });
+            disposer.IsBackground = true;
+            disposer.Start();
+            AssertTrue(readerBlocked.WaitOne(TimeSpan.FromSeconds(4)), "reader reaches its stop signal while disposal is in progress");
+            AssertTrue(!waitHandleDisposeStarted.WaitOne(TimeSpan.FromMilliseconds(200)), "parent does not dispose wait handles before the reader exits");
+            releaseReader.Set();
+            AssertTrue(disposer.Join(TimeSpan.FromSeconds(4)), "disposal completes after the reader is released");
+            AssertTrue(disposeError == null, "disposal does not throw after a remote fault");
+            AssertTrue(waitHandleDisposeStarted.WaitOne(TimeSpan.Zero), "wait handles are disposed only after the reader has exited");
+            client = null;
+        }
+        finally
+        {
+            releaseReader.Set();
+            if (disposer != null && disposer.IsAlive) { disposer.Join(TimeSpan.FromSeconds(4)); }
+            if (client != null) { client.Dispose(); }
+            if (readerHook != null) { readerHook.SetValue(null, null); }
+            if (waitHandleDisposeHook != null) { waitHandleDisposeHook.SetValue(null, null); }
+            readerBlocked.Dispose(); releaseReader.Dispose(); waitHandleDisposeStarted.Dispose();
+            PeerArguments = "--peer";
         }
     }
 
@@ -67,17 +147,10 @@ internal static class TrayHostParentClientSelfTest
     {
         try
         {
-            if (args.Length == 1 && args[0] == "--peer") { RunPeer(); return 0; }
+            if (args.Length == 1 && args[0] == "--peer") { RunPeer(false); return 0; }
+            if (args.Length == 1 && args[0] == "--fault-peer") { RunPeer(true); return 0; }
             TrayHostParentClient.TestProcessFactory = StartPeer;
-            Process current = Process.GetCurrentProcess();
-            TrayHostStartOptions options = new TrayHostStartOptions {
-                ExePath = current.MainModule.FileName,
-                RuntimeId = "test-runtime",
-                ParentPid = current.Id,
-                ParentCreationFileTimeUtc = current.StartTime.ToFileTimeUtc(),
-                InitialPresentation = Snapshot(1UL)
-            };
-            TrayHostParentClient client = TrayHostParentClient.Start(options);
+            TrayHostParentClient client = TrayHostParentClient.Start(Options());
             AssertTrue(client.Receipt.ProtocolMajor == 1 && client.GetHealth() == TrayHostHealth.Ready, "parent waits for verified ready");
             AssertTrue(client.TryPublish(Snapshot(2UL)), "parent publishes presentation without blocking");
             AssertTrue(client.WaitForActivity(TimeSpan.FromSeconds(2)), "parent observes host acknowledgement");
@@ -86,7 +159,9 @@ internal static class TrayHostParentClientSelfTest
             AssertTrue(client.BeginShutdown(ShutdownReason.SupervisorExit, 2UL), "shutdown is accepted");
             AssertTrue(client.WaitForStopped(TimeSpan.FromSeconds(2)), "shutdown completes within deadline");
             client.Dispose();
-            Console.WriteLine("TrayHost parent-client self-tests passed: 1");
+            TestDisposeRequestsGracefulShutdown();
+            TestDisposeAfterRemoteFaultDoesNotCrashParentReader();
+            Console.WriteLine("TrayHost parent-client self-tests passed: 3");
             return 0;
         }
         catch (Exception error)


### PR DESCRIPTION
Summary: prevent TrayHost reader/writer disposal races from terminating the persistent supervisor; preserve graceful shutdown before pipe teardown; add a native fault-disposal regression test; release v2.4.21. Verification: npm test; ParentClient and production TrayHost self-tests; build/build.ps1 -Version 2.4.21.