### PR TITLE
Activate ordinary Codex through Windows AUMID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.4.22
+
+### English
+
+- Fixed **Restart now** closing Codex without reopening it by activating the ordinary packaged app through Windows' native Application Activation Manager.
+- Ordinary launches now use the exact Codex AUMID `OpenAI.Codex_2p2nqsd0c76g0!App`; controlled launches with debugging arguments keep their existing verified executable path.
+- Added a regression test that rejects direct WindowsApps executable launches for ordinary Codex recovery.
+
+### 简体中文
+
+- 修复选择 **立即重启** 后只关闭 Codex、没有重新启动的问题：普通打包应用改由 Windows 原生 Application Activation Manager 激活。
+- 普通启动使用精确 Codex AUMID `OpenAI.Codex_2p2nqsd0c76g0!App`；携带调试参数的受控启动继续使用现有验证路径。
+- 新增回归测试，禁止普通 Codex 恢复流程直接运行 WindowsApps 中的可执行文件。
+
 ## v2.4.21
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.4.21-setup.exe` and `CodexRemote-fix-2.4.21-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.4.21-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.4.22-setup.exe` and `CodexRemote-fix-2.4.22-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.4.22-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. When the tray icon is green, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,12 @@ needed after upgrading.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.4.22
+
+- Fixed **Restart now** closing Codex without reopening it by using Windows' native packaged-app activation API.
+- Ordinary recovery uses the exact Codex AUMID instead of executing the WindowsApps binary directly.
+- Added a regression test that keeps ordinary and controlled launch paths separate.
 
 ## What's new in v2.4.21
 
@@ -120,8 +126,8 @@ supervisor are working.
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.4.21 release includes the ready-to-run `CodexRemote-fix-2.4.21-setup.exe`
-and `CodexRemote-fix-2.4.21-setup.exe.sha256.txt`.
+so the 2.4.22 release includes the ready-to-run `CodexRemote-fix-2.4.22-setup.exe`
+and `CodexRemote-fix-2.4.22-setup.exe.sha256.txt`.
 
 Each release appends a short English change summary to the GitHub release body. The README and
 [CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.21-setup.exe` 和 `CodexRemote-fix-2.4.21-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.4.21-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.22-setup.exe` 和 `CodexRemote-fix-2.4.22-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.4.22-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。托盘图标为绿色时，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.4.22 更新内容
+
+- 修复选择“立即重启”后只关闭 Codex、没有重新启动的问题，改用 Windows 原生打包应用激活接口。
+- 普通恢复流程使用精确 Codex AUMID，不再直接运行 WindowsApps 中的 EXE。
+- 新增回归测试，严格区分普通启动与受控启动路径。
 
 ## v2.4.21 更新内容
 
@@ -113,8 +119,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
 `.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此后续每次更新都会
-为 2.4.21 发布提供可直接运行的 `CodexRemote-fix-2.4.21-setup.exe`
-及 `CodexRemote-fix-2.4.21-setup.exe.sha256.txt`。
+为 2.4.22 发布提供可直接运行的 `CodexRemote-fix-2.4.22-setup.exe`
+及 `CodexRemote-fix-2.4.22-setup.exe.sha256.txt`。
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.4.21",
+  "version": "2.4.22",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/modules/ProcessControl.psm1
+++ b/src/persistence/modules/ProcessControl.psm1
@@ -27,6 +27,7 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Ccod.Persistence.Native {
     public sealed class ProcessIdentityResult {
@@ -123,6 +124,46 @@ namespace Ccod.Persistence.Native {
                     PackageFamilyName = ReadFamily(process)
                 };
             } finally { CloseHandle(process); }
+        }
+    }
+
+    [Flags]
+    internal enum ActivateOptions : uint { None = 0 }
+
+    [ComImport]
+    [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IApplicationActivationManager {
+        [PreserveSig]
+        int ActivateApplication(
+            [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+            ActivateOptions options,
+            out uint processId);
+    }
+
+    [ComImport]
+    [Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+    internal class ApplicationActivationManager { }
+
+    public static class PackagedApplicationV1 {
+        public static int Activate(string appUserModelId) {
+            if (String.IsNullOrWhiteSpace(appUserModelId) ||
+                !Regex.IsMatch(appUserModelId, "^[A-Za-z0-9._-]{1,128}![A-Za-z0-9._-]{1,64}$", RegexOptions.CultureInvariant)) {
+                throw new ArgumentException("A canonical AppUserModelId is required.");
+            }
+            object raw = null;
+            try {
+                raw = new ApplicationActivationManager();
+                IApplicationActivationManager manager = (IApplicationActivationManager)raw;
+                uint processId;
+                int result = manager.ActivateApplication(appUserModelId, null, ActivateOptions.None, out processId);
+                if (result < 0) Marshal.ThrowExceptionForHR(result);
+                if (processId == 0 || processId > Int32.MaxValue) throw new InvalidOperationException("Packaged application activation returned an invalid process id.");
+                return (int)processId;
+            } finally {
+                if (raw != null && Marshal.IsComObject(raw)) Marshal.FinalReleaseComObject(raw);
+            }
         }
     }
 
@@ -416,6 +457,13 @@ function Get-CcodProcessAdapters {
             }
             if (-not [string]::IsNullOrWhiteSpace([string]$WindowStyle)) { $parameters.WindowStyle = [string]$WindowStyle }
             Start-Process @parameters
+        }
+        ActivatePackagedApplication = {
+            param($AppUserModelId)
+            Initialize-CcodProcessNativeApi
+            $processId = [Ccod.Persistence.Native.PackagedApplicationV1]::Activate([string]$AppUserModelId)
+            if ($processId -lt 1) { return $null }
+            [pscustomobject]@{ Id = [int]$processId }
         }
     }
     if ($null -ne $Adapters) {
@@ -1582,7 +1630,12 @@ function Start-CcodProcess {
         $deadline = $transactionTime.AddMilliseconds($StartupTimeoutMilliseconds)
     }
 
-    $process = & $adapter.StartProcess ([string]$package.ExecutablePath) $arguments $null
+    if ($Mode -ceq 'Ordinary') {
+        $appUserModelId = '{0}!App' -f [string]$package.FamilyName
+        $process = & $adapter.ActivatePackagedApplication $appUserModelId
+    } else {
+        $process = & $adapter.StartProcess ([string]$package.ExecutablePath) $arguments $null
+    }
     if ($null -eq $process) { return New-CcodStartResult -Outcome 'Failed' -Snapshot $null -Process $null }
     if ($Mode -ceq 'Special') {
         while ($true) {

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1131,19 +1131,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.21 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.22 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.4.21' ([string]$package.version) 'package version is exactly 2.4.21'
+    Assert-CcodEqual '2.4.22' ([string]$package.version) 'package version is exactly 2.4.22'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.4.21-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.22-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.4.21-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.22-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 $results += Invoke-CcodTest 'installer stops the running supervisor before replacing the installed version' {
@@ -1330,16 +1330,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.21-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/ProcessControl.SelfTest.ps1
+++ b/tests/persistence/ProcessControl.SelfTest.ps1
@@ -902,6 +902,29 @@ try {
         Assert-CcodEqual 1 $calls.Package 'launch path is dynamically resolved even when adopting'
     }
 
+    Invoke-CcodTest 'activates an ordinary packaged Codex by exact AUMID instead of launching the WindowsApps executable' {
+        $calls = [pscustomobject]@{ Packaged = 0; Direct = 0; Aumid = $null }
+        $result = Start-CcodProcess -Mode Ordinary -Adapters @{
+            GetPackageIdentity = { [pscustomobject]@{ Found=$true; FullName='OpenAI.Codex_1.0.0.0_x64__2p2nqsd0c76g0'; FamilyName='OpenAI.Codex_2p2nqsd0c76g0'; Version='1.0.0.0'; ExecutablePath='C:\Codex\ChatGPT.exe' } }
+            GetCurrentSessionId = { 1 }
+            GetCurrentUserSid = { 'S-1-5-21-test' }
+            ListProcessIds = { @() }
+            GetProcess = { param($ProcessId, $StatusEvidence) $null }
+            ActivatePackagedApplication = {
+                param($AppUserModelId)
+                $calls.Packaged++
+                $calls.Aumid = $AppUserModelId
+                [pscustomobject]@{ Id = 700 }
+            }.GetNewClosure()
+            StartProcess = { param($FilePath, $Arguments, $WindowStyle) $calls.Direct++; throw 'ordinary packaged activation must not use the executable path' }.GetNewClosure()
+        }
+        Assert-CcodEqual 'Started' $result.Outcome 'ordinary packaged activation returns started'
+        Assert-CcodEqual 1 $calls.Packaged 'packaged activation boundary is called once'
+        Assert-CcodEqual 'OpenAI.Codex_2p2nqsd0c76g0!App' $calls.Aumid 'exact current Codex AUMID is used'
+        Assert-CcodEqual 0 $calls.Direct 'ordinary activation never executes the WindowsApps binary directly'
+        Assert-CcodEqual 700 $result.Process.Id 'activation receipt is preserved for diagnostics'
+    }
+
     Invoke-CcodTest 'rechecks special ports and launches Codex visibly' {
         $calls = [pscustomobject]@{ Start = 0; Availability = @(); Path = $null; Arguments = @(); WindowStyle = 'unset' }
         $command = '"C:\Codex\ChatGPT.exe" --remote-debugging-address=127.0.0.1 --remote-debugging-port=41001 --inspect=127.0.0.1:41002'


### PR DESCRIPTION
Summary: fix Restart now closing Codex without reopening it; activate the ordinary packaged app through IApplicationActivationManager using the exact Codex AUMID; keep controlled debug launches on the verified executable path; release v2.4.22. Verification: ProcessControl regression self-test, npm test, and build/build.ps1 -Version 2.4.22.