### PR TITLE
Use Defender-compatible AppsFolder activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.4.23
+
+### English
+
+- Replaced the embedded COM application activator with the standard Windows `explorer.exe shell:AppsFolder\<AUMID>` route.
+- Preserved reliable ordinary Codex relaunch while removing the new embedded interop signature that triggered Defender's `Program:Win32/Contebrew.A!ml` download heuristic.
+- Added regression coverage that forbids the embedded COM activator and verifies the exact AppsFolder launch request.
+
+### 简体中文
+
+- 将内嵌 COM 应用激活器替换为 Windows 标准 `explorer.exe shell:AppsFolder\<AUMID>` 路径。
+- 在保留普通 Codex 可靠重启的同时，移除触发 Defender `Program:Win32/Contebrew.A!ml` 下载启发式检测的新增互操作特征。
+- 新增回归测试，禁止内嵌 COM 激活器，并验证精确的 AppsFolder 启动请求。
+
 ## v2.4.22
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.4.22-setup.exe` and `CodexRemote-fix-2.4.22-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.4.22-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.4.23-setup.exe` and `CodexRemote-fix-2.4.23-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.4.23-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. When the tray icon is green, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,12 @@ needed after upgrading.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.4.23
+
+- Replaced the embedded COM activator with the standard Windows AppsFolder launch route.
+- Preserved reliable **Restart now** behavior while removing the signature that triggered Defender's download heuristic.
+- Added regression coverage for the exact Explorer AppsFolder activation request.
 
 ## What's new in v2.4.22
 
@@ -126,8 +132,8 @@ supervisor are working.
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.4.22 release includes the ready-to-run `CodexRemote-fix-2.4.22-setup.exe`
-and `CodexRemote-fix-2.4.22-setup.exe.sha256.txt`.
+so the 2.4.23 release includes the ready-to-run `CodexRemote-fix-2.4.23-setup.exe`
+and `CodexRemote-fix-2.4.23-setup.exe.sha256.txt`.
 
 Each release appends a short English change summary to the GitHub release body. The README and
 [CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.22-setup.exe` 和 `CodexRemote-fix-2.4.22-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.4.22-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.23-setup.exe` 和 `CodexRemote-fix-2.4.23-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.4.23-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。托盘图标为绿色时，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.4.23 更新内容
+
+- 移除内嵌 COM 激活器，改用 Windows 标准 AppsFolder 启动路径。
+- 保留“立即重启”的可靠启动能力，同时消除触发 Defender 下载启发式检测的新增特征。
+- 新增回归测试，验证精确的 Explorer AppsFolder 激活请求。
 
 ## v2.4.22 更新内容
 
@@ -119,8 +125,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
 `.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此后续每次更新都会
-为 2.4.22 发布提供可直接运行的 `CodexRemote-fix-2.4.22-setup.exe`
-及 `CodexRemote-fix-2.4.22-setup.exe.sha256.txt`。
+为 2.4.23 发布提供可直接运行的 `CodexRemote-fix-2.4.23-setup.exe`
+及 `CodexRemote-fix-2.4.23-setup.exe.sha256.txt`。
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.4.22",
+  "version": "2.4.23",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/modules/ProcessControl.psm1
+++ b/src/persistence/modules/ProcessControl.psm1
@@ -27,7 +27,6 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Ccod.Persistence.Native {
     public sealed class ProcessIdentityResult {
@@ -124,46 +123,6 @@ namespace Ccod.Persistence.Native {
                     PackageFamilyName = ReadFamily(process)
                 };
             } finally { CloseHandle(process); }
-        }
-    }
-
-    [Flags]
-    internal enum ActivateOptions : uint { None = 0 }
-
-    [ComImport]
-    [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface IApplicationActivationManager {
-        [PreserveSig]
-        int ActivateApplication(
-            [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
-            [MarshalAs(UnmanagedType.LPWStr)] string arguments,
-            ActivateOptions options,
-            out uint processId);
-    }
-
-    [ComImport]
-    [Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
-    internal class ApplicationActivationManager { }
-
-    public static class PackagedApplicationV1 {
-        public static int Activate(string appUserModelId) {
-            if (String.IsNullOrWhiteSpace(appUserModelId) ||
-                !Regex.IsMatch(appUserModelId, "^[A-Za-z0-9._-]{1,128}![A-Za-z0-9._-]{1,64}$", RegexOptions.CultureInvariant)) {
-                throw new ArgumentException("A canonical AppUserModelId is required.");
-            }
-            object raw = null;
-            try {
-                raw = new ApplicationActivationManager();
-                IApplicationActivationManager manager = (IApplicationActivationManager)raw;
-                uint processId;
-                int result = manager.ActivateApplication(appUserModelId, null, ActivateOptions.None, out processId);
-                if (result < 0) Marshal.ThrowExceptionForHR(result);
-                if (processId == 0 || processId > Int32.MaxValue) throw new InvalidOperationException("Packaged application activation returned an invalid process id.");
-                return (int)processId;
-            } finally {
-                if (raw != null && Marshal.IsComObject(raw)) Marshal.FinalReleaseComObject(raw);
-            }
         }
     }
 
@@ -458,16 +417,18 @@ function Get-CcodProcessAdapters {
             if (-not [string]::IsNullOrWhiteSpace([string]$WindowStyle)) { $parameters.WindowStyle = [string]$WindowStyle }
             Start-Process @parameters
         }
-        ActivatePackagedApplication = {
-            param($AppUserModelId)
-            Initialize-CcodProcessNativeApi
-            $processId = [Ccod.Persistence.Native.PackagedApplicationV1]::Activate([string]$AppUserModelId)
-            if ($processId -lt 1) { return $null }
-            [pscustomobject]@{ Id = [int]$processId }
-        }
     }
     if ($null -ne $Adapters) {
         foreach ($name in $Adapters.Keys) { $resolved[$name] = $Adapters[$name] }
+    }
+    if ($null -eq $Adapters -or -not $Adapters.ContainsKey('ActivatePackagedApplication')) {
+        $resolved.ActivatePackagedApplication = {
+            param($AppUserModelId)
+            if ($AppUserModelId -isnot [string] -or $AppUserModelId -cnotmatch '^[A-Za-z0-9._-]{1,128}![A-Za-z0-9._-]{1,64}$') { return $null }
+            $explorerPath = [IO.Path]::GetFullPath((Join-Path $env:WINDIR 'explorer.exe'))
+            if (-not [IO.File]::Exists($explorerPath)) { return $null }
+            & $resolved.StartProcess $explorerPath @("shell:AppsFolder\$AppUserModelId") $null
+        }.GetNewClosure()
     }
     if ($null -eq $Adapters -or -not $Adapters.ContainsKey('ProbeSpecial')) {
         $resolved.ProbeSpecial = {

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1131,19 +1131,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.22 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.23 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.4.22' ([string]$package.version) 'package version is exactly 2.4.22'
+    Assert-CcodEqual '2.4.23' ([string]$package.version) 'package version is exactly 2.4.23'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.4.22-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.23-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.4.22-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.23-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 $results += Invoke-CcodTest 'installer stops the running supervisor before replacing the installed version' {
@@ -1330,16 +1330,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.22-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/ProcessControl.SelfTest.ps1
+++ b/tests/persistence/ProcessControl.SelfTest.ps1
@@ -925,6 +925,29 @@ try {
         Assert-CcodEqual 700 $result.Process.Id 'activation receipt is preserved for diagnostics'
     }
 
+    Invoke-CcodTest 'default packaged activation uses Explorer AppsFolder without embedding a COM activator' {
+        $source = Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\persistence\modules\ProcessControl.psm1') -Raw
+        Assert-CcodTrue ($source -cnotmatch 'ApplicationActivationManager|PackagedApplicationV1|45BA127D-10A8-46EA-8AB7-56EA9078943C') 'packaged installer source contains no embedded COM activator signature'
+        Assert-CcodTrue ($source -cmatch 'shell:AppsFolder\\') 'packaged activation uses the standard Windows AppsFolder shell route'
+
+        $call = [pscustomobject]@{ Path=$null; Arguments=@(); WindowStyle='unset' }
+        $start = {
+            param($FilePath,$Arguments,$WindowStyle)
+            $call.Path=$FilePath;$call.Arguments=@($Arguments);$call.WindowStyle=$WindowStyle
+            [pscustomobject]@{ Id=701 }
+        }.GetNewClosure()
+        $module = Get-Module -Name ProcessControl -ErrorAction Stop
+        $receipt = & $module {
+            param($StartCallback)
+            $adapter = Get-CcodProcessAdapters -Adapters @{ StartProcess=$StartCallback }
+            & $adapter.ActivatePackagedApplication 'OpenAI.Codex_2p2nqsd0c76g0!App'
+        } $start
+        Assert-CcodEqual ([IO.Path]::GetFullPath((Join-Path $env:WINDIR 'explorer.exe'))) $call.Path 'AppsFolder activation uses the system Explorer path'
+        Assert-CcodEqual 'shell:AppsFolder\OpenAI.Codex_2p2nqsd0c76g0!App' ($call.Arguments -join ',') 'AppsFolder activation carries only the exact Codex AUMID'
+        Assert-CcodEqual $null $call.WindowStyle 'AppsFolder activation is visible'
+        Assert-CcodEqual 701 $receipt.Id 'shell activation receipt is preserved'
+    }
+
     Invoke-CcodTest 'rechecks special ports and launches Codex visibly' {
         $calls = [pscustomobject]@{ Start = 0; Availability = @(); Path = $null; Arguments = @(); WindowStyle = 'unset' }
         $command = '"C:\Codex\ChatGPT.exe" --remote-debugging-address=127.0.0.1 --remote-debugging-port=41001 --inspect=127.0.0.1:41002'


### PR DESCRIPTION
Summary: remove the embedded ApplicationActivationManager COM interop that triggered Program:Win32/Contebrew.A!ml; use the standard Explorer AppsFolder route for ordinary packaged Codex activation; retain reliable Restart now behavior; release v2.4.23. Verification: ProcessControl and install lifecycle tests, npm test, Inno build, Defender custom scan, and Defender scan with an Internet Zone marker all passed with zero new detections.