### PR TITLE
Wait for prior supervisor task before restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.4.24
+
+### English
+
+- Fixed upgrades leaving no tray icon even though the controlled Codex session was active.
+- The installer now waits for the previous `IgnoreNew` scheduled-task instance to leave `Running` before starting the new Supervisor.
+- Added lifecycle regression coverage and a stable `CCOD_INSTALL_SUPERVISOR_TASK_BUSY` failure when the old task cannot exit within the bounded wait.
+
+### 简体中文
+
+- 修复升级后受控 Codex 会话已经生效、但托盘图标消失的问题。
+- 安装器现在会等待旧 `IgnoreNew` 计划任务实例退出 `Running`，再启动新的 Supervisor。
+- 新增生命周期回归测试；旧任务在限定时间内无法退出时，会返回稳定错误 `CCOD_INSTALL_SUPERVISOR_TASK_BUSY`。
+
 ## v2.4.23
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.4.23-setup.exe` and `CodexRemote-fix-2.4.23-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.4.23-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.4.24-setup.exe` and `CodexRemote-fix-2.4.24-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.4.24-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. When the tray icon is green, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,12 @@ needed after upgrading.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.4.24
+
+- Fixed upgrades leaving the controlled Codex session active but no tray supervisor running.
+- The installer now waits for the previous `IgnoreNew` scheduled-task instance to stop before starting the new Supervisor.
+- Added a bounded lifecycle regression test for this upgrade race.
 
 ## What's new in v2.4.23
 
@@ -132,8 +138,8 @@ supervisor are working.
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.4.23 release includes the ready-to-run `CodexRemote-fix-2.4.23-setup.exe`
-and `CodexRemote-fix-2.4.23-setup.exe.sha256.txt`.
+so the 2.4.24 release includes the ready-to-run `CodexRemote-fix-2.4.24-setup.exe`
+and `CodexRemote-fix-2.4.24-setup.exe.sha256.txt`.
 
 Each release appends a short English change summary to the GitHub release body. The README and
 [CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.23-setup.exe` 和 `CodexRemote-fix-2.4.23-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.4.23-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.4.24-setup.exe` 和 `CodexRemote-fix-2.4.24-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.4.24-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。托盘图标为绿色时，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.4.24 更新内容
+
+- 修复升级后受控 Codex 已生效、但托盘 Supervisor 没有运行的问题。
+- 安装器会等待旧 `IgnoreNew` 计划任务实例停止后，再启动新 Supervisor。
+- 新增该升级竞态的有界生命周期回归测试。
 
 ## v2.4.23 更新内容
 
@@ -125,8 +131,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
 `.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此后续每次更新都会
-为 2.4.23 发布提供可直接运行的 `CodexRemote-fix-2.4.23-setup.exe`
-及 `CodexRemote-fix-2.4.23-setup.exe.sha256.txt`。
+为 2.4.24 发布提供可直接运行的 `CodexRemote-fix-2.4.24-setup.exe`
+及 `CodexRemote-fix-2.4.24-setup.exe.sha256.txt`。
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.4.23",
+  "version": "2.4.24",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/modules/InstallLifecycle.psm1
+++ b/src/persistence/modules/InstallLifecycle.psm1
@@ -666,6 +666,16 @@ function Get-CcodLifecycleAdapters {
         StartSupervisorTask = {
             Start-ScheduledTask -TaskName $script:CcodLifecycleTaskName -ErrorAction Stop | Out-Null
         }
+        WaitSupervisorTaskIdle = {
+            param($TimeoutMilliseconds)
+            $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+            while ($stopwatch.ElapsedMilliseconds -lt [long]$TimeoutMilliseconds) {
+                $task = Get-ScheduledTask -TaskName $script:CcodLifecycleTaskName -ErrorAction Stop
+                if ([string]$task.State -cne 'Running') { return $true }
+                Start-Sleep -Milliseconds 100
+            }
+            return $false
+        }
         SignalSupervisorShutdown = {
             param($UserSid, $SessionId)
             try {
@@ -784,6 +794,10 @@ function Install-CcodLifecycleTask {
 
 function Start-CcodLifecycleTask {
     param([Parameter(Mandatory)][hashtable]$Adapters)
+    $idle = & $Adapters.WaitSupervisorTaskIdle 10000
+    if ($idle -isnot [bool] -or -not $idle) {
+        Throw-CcodLifecycleError 'CCOD_INSTALL_SUPERVISOR_TASK_BUSY' 'The previous IgnoreNew supervisor task instance did not exit before restart' $script:CcodLifecycleTaskName
+    }
     & $Adapters.StartSupervisorTask
 }
 

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -86,6 +86,8 @@ function New-CcodLifecycleFake {
         TaskInstalled = 0
         TaskRemoved = 0
         TaskStarted = 0
+        TaskIdle = $true
+        TaskIdleWaits = 0
         AutomationPaused = 0
         TransitionLeaseCalls = 0
         ShutdownSignaled = 0
@@ -120,6 +122,7 @@ function New-CcodLifecycleFake {
     $adapters.InstallSupervisorTask = { param($InstallRoot, $UserSid) $world.Calls.Add("InstallTask:$([IO.Path]::GetFileName($InstallRoot)):$UserSid"); $world.TaskInstalled++ }.GetNewClosure()
     $adapters.RemoveSupervisorTask = { $world.Calls.Add('RemoveTask'); $world.TaskRemoved++ }.GetNewClosure()
     $adapters.StartSupervisorTask = { $world.Calls.Add('StartTask'); $world.TaskStarted++ }.GetNewClosure()
+    $adapters.WaitSupervisorTaskIdle = { param($TimeoutMilliseconds) $world.Calls.Add("WaitTaskIdle:$TimeoutMilliseconds"); $world.TaskIdleWaits++; [bool]$world.TaskIdle }.GetNewClosure()
     $adapters.SignalSupervisorShutdown = { param($UserSid, $SessionId) $world.Calls.Add("SignalShutdown:${UserSid}:${SessionId}"); $world.ShutdownSignaled++ }.GetNewClosure()
     $adapters.FindSupervisorFallback = { param($InstallRoot, $Identity) $world.Calls.Add("FindSupervisorFallback:$([IO.Path]::GetFileName($InstallRoot)):$($Identity.UserSid):$($Identity.SessionId)"); $world.FallbackSupervisorLookups++; $world.FallbackSupervisor }.GetNewClosure()
     $adapters.WaitSupervisorExit = { param($SupervisorIdentity, $TimeoutMilliseconds) $world.Calls.Add("WaitSupervisor:$($SupervisorIdentity.Pid):$TimeoutMilliseconds"); [bool]$world.WaitSupervisorExit }.GetNewClosure()
@@ -199,6 +202,27 @@ function Set-CcodLifecycleTestStatus {
 }
 
 $results = @()
+
+$results += Invoke-CcodTest 'waits for the previous IgnoreNew task instance before starting the new supervisor' {
+    $module = Get-Module -Name InstallLifecycle -ErrorAction Stop
+    $calls = [Collections.Generic.List[string]]::new()
+    $adapters = @{
+        WaitSupervisorTaskIdle = { param($TimeoutMilliseconds) $calls.Add("wait:$TimeoutMilliseconds"); $true }.GetNewClosure()
+        StartSupervisorTask = { $calls.Add('start') }.GetNewClosure()
+    }
+    & $module { param($LifecycleAdapters) Start-CcodLifecycleTask -Adapters $LifecycleAdapters } $adapters
+    Assert-CcodEqual 'wait:10000,start' ($calls -join ',') 'task idle proof precedes the start request'
+
+    $blockedCalls = [Collections.Generic.List[string]]::new()
+    $blockedAdapters = @{
+        WaitSupervisorTaskIdle = { param($TimeoutMilliseconds) $blockedCalls.Add('wait'); $false }.GetNewClosure()
+        StartSupervisorTask = { $blockedCalls.Add('start'); throw 'must not start while the old IgnoreNew instance is running' }.GetNewClosure()
+    }
+    $threw = $false
+    try { & $module { param($LifecycleAdapters) Start-CcodLifecycleTask -Adapters $LifecycleAdapters } $blockedAdapters } catch { $threw = $_.FullyQualifiedErrorId -like 'CCOD_INSTALL_SUPERVISOR_TASK_BUSY*' }
+    Assert-CcodTrue $threw 'a task that remains running fails with the stable busy code'
+    Assert-CcodEqual 'wait' ($blockedCalls -join ',') 'blocked task never receives a start request'
+}
 
 $results += Invoke-CcodTest 'default installer validation uses the structural runtime payload and requires TrayHost files' {
     $source = New-CcodLifecycleTempRoot
@@ -1131,19 +1155,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.23 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.4.24 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.4.23' ([string]$package.version) 'package version is exactly 2.4.23'
+    Assert-CcodEqual '2.4.24' ([string]$package.version) 'package version is exactly 2.4.24'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.4.23-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.24-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.4.23-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.4.24-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 $results += Invoke-CcodTest 'installer stops the running supervisor before replacing the installed version' {
@@ -1330,16 +1354,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.24-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.4\.24-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.23-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.24-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.4\.24-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 


### PR DESCRIPTION
Summary: fix upgrades leaving an active controlled Codex session but no tray supervisor; wait for the previous IgnoreNew task instance to leave Running before starting the new runtime; fail with CCOD_INSTALL_SUPERVISOR_TASK_BUSY on bounded timeout; release v2.4.24. Verification: install lifecycle red-green regression, ProcessControl regression, runtime and package tests, all non-Bootstrap persistence tests, Inno build, Defender local and Internet Zone scans. The local Bootstrap test is intentionally blocked by the live installed supervisor mutex; full validation runs on the clean Windows CI runner.