### PR TITLE
fix: close uninstaller payload dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.5.2
+
+### English
+
+- Fixed the fail-closed uninstaller payload to include `TrustedLogonIdentity.psm1`, required by the staged `StateStore` dependency.
+- Added a regression that imports staged `InstallLifecycle` before cleanup, proving its payload-local dependency closure is complete.
+
+### 简体中文
+
+- 修复失败即停止的卸载载荷，补齐 staged `StateStore` 依赖的 `TrustedLogonIdentity.psm1`。
+- 新增回归：在清理前导入 staged `InstallLifecycle`，证明其载荷内依赖闭包完整。
+
 ## v2.5.1
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.5.1-setup.exe` and `CodexRemote-fix-2.5.1-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.5.1-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.5.2-setup.exe` and `CodexRemote-fix-2.5.2-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.5.2-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. Setup waits until the new runtime and TrayHost are ready, then offers **Restart now** or **Later**. Choose **Restart now** only when it is safe for Codex to close and relaunch into a repaired session; choose **Later** to leave the current Codex session untouched and resume safely after a later manual or normal Codex launch. When the connection reports **Connected**, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,11 @@ upgrade.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.5.2
+
+- Fixed the fail-closed uninstaller staging payload so `StateStore` can load its required `TrustedLogonIdentity` dependency before cleanup.
+- Added an external-payload import regression that proves the staged cleanup module has its complete dependency closure before any deletion.
 
 ## What's new in v2.5.1
 
@@ -152,8 +157,8 @@ The tray reports two independent, truthful status lines instead of inferring rea
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.5.1 release includes the ready-to-run `CodexRemote-fix-2.5.1-setup.exe`
-and `CodexRemote-fix-2.5.1-setup.exe.sha256.txt`.
+so the 2.5.2 release includes the ready-to-run `CodexRemote-fix-2.5.2-setup.exe`
+and `CodexRemote-fix-2.5.2-setup.exe.sha256.txt`.
 
 Each release appends a short English change summary to the GitHub release body. The README and
 [CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.1-setup.exe` 和 `CodexRemote-fix-2.5.1-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.5.1-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.2-setup.exe` 和 `CodexRemote-fix-2.5.2-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.5.2-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。安装器会等待新 runtime 与 TrayHost 就绪，再让你选择 **立即重启** 或 **稍后**：仅在可以关闭并重新启动 Codex 时选择 **立即重启**；选择 **稍后** 会保持当前 Codex 会话不受影响，并会在之后手动或正常启动 Codex 时安全恢复。连接状态显示 **已连接** 后，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,11 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.5.2 更新内容
+
+- 修复失败即停止的卸载 staging 载荷，确保清理前 `StateStore` 能加载所需的 `TrustedLogonIdentity` 依赖。
+- 新增外部载荷导入回归，在任何删除操作前证明 staged 清理模块拥有完整依赖闭包。
 
 ## v2.5.1 更新内容
 
@@ -144,9 +149,9 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 ## 发布（Releases）
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
-`.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此 2.5.1 发布提供
-可直接运行的 `CodexRemote-fix-2.5.1-setup.exe`
-及 `CodexRemote-fix-2.5.1-setup.exe.sha256.txt`。
+`.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此 2.5.2 发布提供
+可直接运行的 `CodexRemote-fix-2.5.2-setup.exe`
+及 `CodexRemote-fix-2.5.2-setup.exe.sha256.txt`。
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/UninstallBootstrap.ps1
+++ b/src/persistence/UninstallBootstrap.ps1
@@ -24,6 +24,7 @@ $script:CcodUninstallPayloadEntries = @(
     'src/persistence/modules/RuntimeManifest.psm1',
     'src/persistence/modules/LifecycleEpoch.psm1',
     'src/persistence/modules/StateStore.psm1',
+    'src/persistence/modules/TrustedLogonIdentity.psm1',
     'src/persistence/modules/ScheduledTask.psm1',
     'src/persistence/modules/KernelObjects.psm1',
     'src/persistence/modules/CompatibilityProbe.psm1',

--- a/src/trayhost/AssemblyInfo.cs
+++ b/src/trayhost/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Persistent native tray host for CodexRemote-fix")]
 [assembly: AssemblyCompany("CodexRemote-fix contributors")]
 [assembly: AssemblyProduct("CodexRemote-fix")]
-[assembly: AssemblyVersion("2.5.1.0")]
-[assembly: AssemblyFileVersion("2.5.1.0")]
+[assembly: AssemblyVersion("2.5.2.0")]
+[assembly: AssemblyFileVersion("2.5.2.0")]
 [assembly: ComVisible(false)]

--- a/src/trayhost/CodexRemote.TrayHost.manifest
+++ b/src/trayhost/CodexRemote.TrayHost.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.5.1.0" name="CodexRemote.fix.TrayHost" type="win32" />
+  <assemblyIdentity version="2.5.2.0" name="CodexRemote.fix.TrayHost" type="win32" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1820,19 +1820,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.5.1 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.5.2 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.1' ([string]$package.version) 'package version is exactly 2.5.1'
+    Assert-CcodEqual '2.5.2' ([string]$package.version) 'package version is exactly 2.5.2'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.5.1-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.5.2-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.5.1-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.5.2-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 # Production mutation caught: allowing raw activation JSON to authorize Ready/Failed, checking the deadline after terminal processing, prompting without a strict validator child exit, or synchronously waiting on an unbounded validator.
@@ -2184,16 +2184,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.1-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.1-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.2-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.2-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.1-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.1-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.2-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.2-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/ReleaseWorkflow.SelfTest.ps1
+++ b/tests/persistence/ReleaseWorkflow.SelfTest.ps1
@@ -188,20 +188,20 @@ Invoke-CcodTest 'package scripts build provenance and workflows retain the relea
     Assert-CcodTrue ($release -cmatch '(?ms)^  publish:\r?\n    needs: build\r?\n    runs-on: windows-latest\r?\n    permissions:\r?\n      contents: write\s*$') 'only the publish job receives release-write permission'
 }
 
-Invoke-CcodTest '2.5.1 current documentation matches the lifecycle tray and uninstall contract' {
+Invoke-CcodTest '2.5.2 current documentation matches the lifecycle tray and uninstall contract' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.1' ([string]$package.version) 'package metadata is the 2.5.1 release'
+    Assert-CcodEqual '2.5.2' ([string]$package.version) 'package metadata is the 2.5.2 release'
 
     $changelog = Get-Content -LiteralPath (Join-Path $repositoryRoot 'CHANGELOG.md') -Raw
-    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.1\s*\r?\n(?<body>.*?)(?=^## |\z)')
-    Assert-CcodTrue $releaseSection.Success 'v2.5.1 release section exists'
+    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.2\s*\r?\n(?<body>.*?)(?=^## |\z)')
+    Assert-CcodTrue $releaseSection.Success 'v2.5.2 release section exists'
     $releaseBody = $releaseSection.Groups['body'].Value
-    Assert-CcodTrue ($releaseBody -match '(?m)^### English\s*$') 'v2.5.1 release section is English'
-    Assert-CcodTrue ($releaseBody.Contains('Fixed a Supervisor startup contract mismatch that rejected the complete schema-two active runtime pointer immediately after installation.')) 'v2.5.1 startup release bullet is exact'
-    Assert-CcodTrue ($releaseBody.Contains('Added regression coverage that reads the canonical active pointer before Supervisor readiness, including upgrade pointers with a previous runtime.')) 'v2.5.1 regression release bullet is exact'
+    Assert-CcodTrue ($releaseBody -match '(?m)^### English\s*$') 'v2.5.2 release section is English'
+    Assert-CcodTrue ($releaseBody.Contains('Fixed the fail-closed uninstaller payload to include `TrustedLogonIdentity.psm1`, required by the staged `StateStore` dependency.')) 'v2.5.2 uninstaller release bullet is exact'
+    Assert-CcodTrue ($releaseBody.Contains('Added a regression that imports staged `InstallLifecycle` before cleanup, proving its payload-local dependency closure is complete.')) 'v2.5.2 regression release bullet is exact'
 
     $readme = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.md') -Raw
-    Assert-CcodTrue ($readme.Contains('CodexRemote-fix-2.5.1-setup.exe')) 'English Quick Start names the 2.5.1 installer'
+    Assert-CcodTrue ($readme.Contains('CodexRemote-fix-2.5.2-setup.exe')) 'English Quick Start names the 2.5.2 installer'
     Assert-CcodTrue ($readme.Contains('## Connection and protection status')) 'English README documents the current status contract'
     foreach ($state in @('Waiting for Codex', 'Checking', 'Connected', 'Repair needed', 'Error', 'Running', 'Reconnecting', 'Stopping')) {
         Assert-CcodTrue ($readme.Contains($state)) "English README documents state: $state"
@@ -215,7 +215,7 @@ Invoke-CcodTest '2.5.1 current documentation matches the lifecycle tray and unin
     Assert-CcodTrue (-not $readme.Contains('Automation, Candidate-compatible trial, Logs, and Uninstall')) 'English README no longer describes removed tray toggles'
 
     $readmeZh = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.zh-CN.md') -Raw -Encoding UTF8
-    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.1-setup.exe')) 'Chinese Quick Start names the 2.5.1 installer'
+    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.2-setup.exe')) 'Chinese Quick Start names the 2.5.2 installer'
     Assert-CcodTrue ($readmeZh -match '## \u8FDE\u63A5\u4E0E\u5B88\u62A4\u72B6\u6001') 'Chinese README documents the current status contract'
     foreach ($statePattern in @('\u7B49\u5F85 Codex', '\u6B63\u5728\u68C0\u67E5', '\u5DF2\u8FDE\u63A5', '\u9700\u8981\u4FEE\u590D', '\u9519\u8BEF', '\u8FD0\u884C\u4E2D', '\u6B63\u5728\u91CD\u8FDE', '\u6B63\u5728\u505C\u6B62')) {
         Assert-CcodTrue ($readmeZh -match $statePattern) "Chinese README documents state pattern: $statePattern"

--- a/tests/persistence/TrayHostBuild.SelfTest.ps1
+++ b/tests/persistence/TrayHostBuild.SelfTest.ps1
@@ -4,14 +4,14 @@ $ErrorActionPreference='Stop'
 $repositoryRoot=Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $lockPath=Join-Path $repositoryRoot 'build\trayhost-packages.lock.json'
 
-Invoke-CcodTest '2.5.1 source metadata binds the package and TrayHost assembly identities' {
+Invoke-CcodTest '2.5.2 source metadata binds the package and TrayHost assembly identities' {
     $package=Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw|ConvertFrom-Json
-    Assert-CcodEqual '2.5.1' ([string]$package.version) 'package version is the 2.5.1 release version'
+    Assert-CcodEqual '2.5.2' ([string]$package.version) 'package version is the 2.5.2 release version'
     $assemblyInfo=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\AssemblyInfo.cs') -Raw
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.1\.0"\)') 'TrayHost assembly version is 2.5.1.0'
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.1\.0"\)') 'TrayHost file version is 2.5.1.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.2\.0"\)') 'TrayHost assembly version is 2.5.2.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.2\.0"\)') 'TrayHost file version is 2.5.2.0'
     $manifest=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\CodexRemote.TrayHost.manifest') -Raw
-    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.1\.0"') 'TrayHost manifest identity is 2.5.1.0'
+    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.2\.0"') 'TrayHost manifest identity is 2.5.2.0'
 }
 
 Invoke-CcodTest 'TrayHost build lock pins the Microsoft net48 reference package' {
@@ -48,14 +48,14 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
     Import-Module $modulePath -Force
     $artifact=Join-Path $env:TEMP ('ccod-trayhost-artifact-'+[Guid]::NewGuid().ToString('N'))
     try{
-        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.1' -OutputDirectory $artifact
+        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.2' -OutputDirectory $artifact
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe') -PathType Leaf) 'TrayHost executable exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe.config') -PathType Leaf) 'TrayHost config exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -PathType Leaf) 'TrayHost provenance exists'
         $provenance=Get-Content -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -Raw|ConvertFrom-Json
-        Assert-CcodEqual '2.5.1' ([string]$provenance.version) 'provenance version is exact'
+        Assert-CcodEqual '2.5.2' ([string]$provenance.version) 'provenance version is exact'
         $fileVersion=[Diagnostics.FileVersionInfo]::GetVersionInfo((Join-Path $artifact 'CodexRemote.TrayHost.exe')).FileVersion
-        Assert-CcodEqual '2.5.1.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
+        Assert-CcodEqual '2.5.2.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
         Assert-CcodTrue ([string]$provenance.gitCommit -cmatch '^[0-9a-f]{40}$') 'provenance records one canonical source commit'
         $provenanceTimestamp=[datetime]::MinValue
         Assert-CcodTrue ([datetime]::TryParse([string]$provenance.buildTimestampUtc,[Globalization.CultureInfo]::InvariantCulture,[Globalization.DateTimeStyles]::RoundtripKind,[ref]$provenanceTimestamp)) 'provenance records a parseable build timestamp'
@@ -67,10 +67,10 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
         Assert-CcodTrue (@($provenance.sourceFiles).Count -ge 10) 'provenance includes every TrayHost source'
         Assert-CcodTrue (-not ([string]$provenance|Select-String -Pattern '[A-Za-z]:\\|\\\\' -Quiet)) 'provenance does not leak absolute paths'
         $currentCommit=(& git -C $repositoryRoot rev-parse HEAD).Trim().ToLowerInvariant()
-        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.1' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
+        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.2' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
         Assert-CcodEqual $currentCommit ([string]$validated.GitCommit) 'artifact validation binds the current source commit when requested'
         $tampered=Join-Path $artifact 'CodexRemote.TrayHost.exe.config'; Add-Content -LiteralPath $tampered -Value 'x'
-        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.1' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
+        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.2' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
         Assert-CcodTrue $threw 'tampered artifact is rejected'
     }finally{if(Test-Path -LiteralPath $artifact){Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue}}
 }

--- a/tests/persistence/UninstallBootstrap.SelfTest.ps1
+++ b/tests/persistence/UninstallBootstrap.SelfTest.ps1
@@ -165,6 +165,7 @@ function New-CcodVerifiedUninstallRuntimeFixture {
         'src/persistence/modules/RuntimeManifest.psm1',
         'src/persistence/modules/LifecycleEpoch.psm1',
         'src/persistence/modules/StateStore.psm1',
+        'src/persistence/modules/TrustedLogonIdentity.psm1',
         'src/persistence/modules/ScheduledTask.psm1',
         'src/persistence/modules/KernelObjects.psm1',
         'src/persistence/modules/CompatibilityProbe.psm1',
@@ -220,7 +221,7 @@ $results += Invoke-CcodTest 'production runtime verification binds the installed
         Assert-CcodEqual $fixture.RuntimeId $context.runtimeId 'verified context binds the active manifest runtime'
         Assert-CcodEqual ([uint64]7) ([uint64]$context.runtimeGeneration) 'verified context binds active generation'
         Assert-CcodEqual ([uint64]11) ([uint64]$context.leaseEpoch) 'verified context binds lifecycle epoch'
-        Assert-CcodEqual 11 @($context.payloadEntries).Count 'only the cleanup entry and its imported modules are staged'
+        Assert-CcodEqual 12 @($context.payloadEntries).Count 'only the cleanup entry and its imported modules are staged'
         [IO.File]::AppendAllText((Join-Path $fixture.RuntimeRoot 'src\persistence\modules\InstallLifecycle.psm1'),'# altered',[Text.UTF8Encoding]::new($false))
         Assert-CcodThrows { Get-CcodUninstallBootstrapVerifiedRuntimeContext -InstallerRoot $repositoryRoot -InstallRoot $installRoot | Out-Null } 'CCOD_UNINSTALL_RUNTIME_INVALID'
     } finally {
@@ -256,13 +257,19 @@ $results += Invoke-CcodTest 'real external staging uses a protected current-user
         $payloadRoot = Join-Path $transactionDirectory 'payload'
         Assert-CcodUninstallBootstrapDirectoryAcl -Path $payloadRoot -UserSid $context.userSid
         $payloadFiles = @(Get-ChildItem -LiteralPath $payloadRoot -Recurse -File -Force)
-        Assert-CcodEqual 11 $payloadFiles.Count 'external payload contains the exact cleanup entry and required modules'
+        Assert-CcodEqual 12 $payloadFiles.Count 'external payload contains the exact cleanup entry and required modules'
         foreach ($entry in @($context.payloadEntries)) {
             $source = Join-Path $fixture.RuntimeRoot ($entry.Replace('/','\'))
             $staged = Join-Path $payloadRoot ($entry.Replace('/','\'))
             Assert-CcodTrue (Test-Path -LiteralPath $staged -PathType Leaf) "manifest-bound payload entry $entry is staged"
             Assert-CcodEqual (Get-CcodTestFileSha256 $source) (Get-CcodTestFileSha256 $staged) "manifest-bound payload entry $entry retains its verified hash"
         }
+        $stagedInstallLifecycle = Join-Path $payloadRoot 'src\persistence\modules\InstallLifecycle.psm1'
+        $importCommand = '$ErrorActionPreference = ''Stop''; $module = Import-Module -Name ''' + $stagedInstallLifecycle.Replace("'","''") + ''' -Force -PassThru -ErrorAction Stop; Remove-Module -Name $module.Name -Force -ErrorAction Stop'
+        $encodedImportCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($importCommand))
+        $importOutput = @(& powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encodedImportCommand 2>&1)
+        Assert-CcodEqual 0 $LASTEXITCODE 'staged InstallLifecycle imports its complete payload-local dependency closure before cleanup'
+        Assert-CcodEqual 0 $importOutput.Count 'successful staged InstallLifecycle import emits no untrusted output'
         Assert-CcodEqual 0 (@($payloadFiles | Where-Object { $_.Name -match 'device|key|credential' })).Count 'external payload has no device key or credential material'
         $stagedBootstrap = Join-Path $payloadRoot 'src\persistence\UninstallBootstrap.ps1'
         $transaction.phase = 'ReadyForInno'

--- a/tests/trayhost/TrayHostNativeSelfTest.cs
+++ b/tests/trayhost/TrayHostNativeSelfTest.cs
@@ -57,9 +57,9 @@ internal static class TrayHostNativeSelfTest
     private static PresentationSnapshot SnapshotV2(ulong revision)
     {
         string[] strings = new string[] {
-            "CodexRemote-fix 2.5.1", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
+            "CodexRemote-fix 2.5.2", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
             "Language / 语言", "Follow system (English)", "中文", "English", "Open logs", "About", "Exit",
-            "About", "CodexRemote-fix | Version 2.5.1", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
+            "About", "CodexRemote-fix | Version 2.5.2", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
         };
         return new PresentationSnapshot(revision, TrayColor.Green, ConnectionState.Connected, ProtectionState.Running, LanguageMode.English,
             PresentationFlags.LanguageEnabled | PresentationFlags.OpenLogsEnabled | PresentationFlags.AboutEnabled | PresentationFlags.ExitEnabled, strings);
@@ -147,7 +147,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform();
         TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         platform.TrackResult = 0; window.HandleContextMenu(new TrayPoint(0, 0));
-        AssertEqual("CodexRemote-fix 2.5.1|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
+        AssertEqual("CodexRemote-fix 2.5.2|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
         AssertTrue(!platform.AppendedText.Contains("Allow compatible update trials"), "candidate toggle is removed");
         AssertTrue(!platform.Commands.Contains(1009U), "tray uninstall command is removed");
         TrayCommand selected = TrayCommand.None; window.CommandSelected += delegate(TrayCommand command, ulong revision) { selected = command; };
@@ -163,7 +163,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform(); TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         window.ShowAbout();
         AssertTrue(platform.MessageBoxes.Count == 1, "verified About shows exactly one native message box");
-        AssertEqual("About|CodexRemote-fix | Version 2.5.1", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
+        AssertEqual("About|CodexRemote-fix | Version 2.5.2", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
         window.Dispose();
     }
 


### PR DESCRIPTION
Fixes the fail-closed uninstall payload closure by staging TrustedLogonIdentity with StateStore. Adds a clean-process staged InstallLifecycle import regression before cleanup and advances the release contract to v2.5.2.

Validated locally: npm test, installed lifecycle harness, release contract, UninstallBootstrap self-test, and production TrayHost self-test.