### PR TITLE
fix: preclaim durable uninstall controller result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.5.4
+
+### English
+
+- Made fail-closed uninstall recovery preclaim a durable nonempty controller result placeholder so it works with a still-manifest-sealed older controller runtime.
+- Added regression coverage for the legacy strict byte-array writer and the prelaunch placeholder ordering.
+
+### 简体中文
+
+- 调整失败即停止的卸载恢复：预占并认证的 controller 结果文件现在会持久写入非空占位内容，因此仍可由清单封存的旧 controller runtime 安全替换。
+- 新增旧版严格字节数组写入器及控制器启动前占位写入顺序的回归覆盖。
+
 ## v2.5.3
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.5.3-setup.exe` and `CodexRemote-fix-2.5.3-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.5.3-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.5.4-setup.exe` and `CodexRemote-fix-2.5.4-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.5.4-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. Setup waits until the new runtime and TrayHost are ready, then offers **Restart now** or **Later**. Choose **Restart now** only when it is safe for Codex to close and relaunch into a repaired session; choose **Later** to leave the current Codex session untouched and resume safely after a later manual or normal Codex launch. When the connection reports **Connected**, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,11 @@ upgrade.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.5.4
+
+- Made fail-closed uninstall recovery preclaim a durable nonempty controller result placeholder so it works with a still-manifest-sealed older controller runtime.
+- Added regression coverage for the legacy strict byte-array writer and the prelaunch placeholder ordering.
 
 ## What's new in v2.5.3
 
@@ -162,8 +167,8 @@ The tray reports two independent, truthful status lines instead of inferring rea
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.5.3 release includes the ready-to-run `CodexRemote-fix-2.5.3-setup.exe`
-and `CodexRemote-fix-2.5.3-setup.exe.sha256.txt`.
+so the 2.5.4 release includes the ready-to-run `CodexRemote-fix-2.5.4-setup.exe`
+and `CodexRemote-fix-2.5.4-setup.exe.sha256.txt`.
 
 Each release appends a short English change summary to the GitHub release body. The README and
 [CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.3-setup.exe` 和 `CodexRemote-fix-2.5.3-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.5.3-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.4-setup.exe` 和 `CodexRemote-fix-2.5.4-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.5.4-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。安装器会等待新 runtime 与 TrayHost 就绪，再让你选择 **立即重启** 或 **稍后**：仅在可以关闭并重新启动 Codex 时选择 **立即重启**；选择 **稍后** 会保持当前 Codex 会话不受影响，并会在之后手动或正常启动 Codex 时安全恢复。连接状态显示 **已连接** 后，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,11 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.5.4 更新内容
+
+- 调整失败即停止的卸载恢复：预占并认证的 controller 结果文件现在会持久写入非空占位内容，因此仍可由清单封存的旧 controller runtime 安全替换。
+- 新增旧版严格字节数组写入器及控制器启动前占位写入顺序的回归覆盖。
 
 ## v2.5.3 更新内容
 
@@ -154,9 +159,9 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 ## 发布（Releases）
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
-`.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此 2.5.3 发布提供
-可直接运行的 `CodexRemote-fix-2.5.3-setup.exe`
-及 `CodexRemote-fix-2.5.3-setup.exe.sha256.txt`。
+`.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此 2.5.4 发布提供
+可直接运行的 `CodexRemote-fix-2.5.4-setup.exe`
+及 `CodexRemote-fix-2.5.4-setup.exe.sha256.txt`。
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/modules/InstallLifecycle.psm1
+++ b/src/persistence/modules/InstallLifecycle.psm1
@@ -772,8 +772,17 @@ function Invoke-CcodLifecycleControllerRecover {
     $stderrPath = [IO.Path]::GetFullPath((Join-Path $requestDirectory "uninstall-$nonce.stderr.log"))
     try {
         [IO.File]::WriteAllText($requestPath, ($request | ConvertTo-Json -Depth 16 -Compress), [Text.UTF8Encoding]::new($false))
+        # The active controller can be from an older, still manifest-sealed runtime.
+        # Keep the CreateNew ownership claim, but make the placeholder nonempty so its
+        # older strict byte-array writer can atomically replace it with the real result.
         $resultPlaceholder = [IO.File]::Open($resultPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
-        $resultPlaceholder.Dispose()
+        try {
+            $resultPlaceholderBytes = [Text.UTF8Encoding]::new($false).GetBytes("{}`n")
+            $resultPlaceholder.Write($resultPlaceholderBytes, 0, $resultPlaceholderBytes.Length)
+            $resultPlaceholder.Flush($true)
+        } finally {
+            $resultPlaceholder.Dispose()
+        }
         $powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
         $arguments = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $controller, '-RequestPath', $requestPath, '-ResultPath', $resultPath)
         $stdout = @(& $powershell @arguments 2>$stderrPath)

--- a/src/trayhost/AssemblyInfo.cs
+++ b/src/trayhost/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Persistent native tray host for CodexRemote-fix")]
 [assembly: AssemblyCompany("CodexRemote-fix contributors")]
 [assembly: AssemblyProduct("CodexRemote-fix")]
-[assembly: AssemblyVersion("2.5.3.0")]
-[assembly: AssemblyFileVersion("2.5.3.0")]
+[assembly: AssemblyVersion("2.5.4.0")]
+[assembly: AssemblyFileVersion("2.5.4.0")]
 [assembly: ComVisible(false)]

--- a/src/trayhost/CodexRemote.TrayHost.manifest
+++ b/src/trayhost/CodexRemote.TrayHost.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.5.3.0" name="CodexRemote.fix.TrayHost" type="win32" />
+  <assemblyIdentity version="2.5.4.0" name="CodexRemote.fix.TrayHost" type="win32" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1592,6 +1592,20 @@ $results += Invoke-CcodTest 'default adapters keep module session state for priv
     Assert-CcodTrue ($commandNames -contains 'Get-CcodLifecycleProjectVersion') 'default GetProjectVersion still targets the private helper'
 }
 
+$results += Invoke-CcodTest 'uninstall recovery preclaims a durable nonempty controller result before launching a legacy runtime controller' {
+    $source = Get-Content -LiteralPath $installLifecycleModule -Raw -Encoding UTF8
+    $recover = [regex]::Match($source, '(?ms)^function Invoke-CcodLifecycleControllerRecover\s*\{(?<body>.*?)(?=^function Get-CcodLifecycleAdapters\s*\{)')
+    Assert-CcodTrue $recover.Success 'controller recovery implementation exists as one bounded function'
+    $body = $recover.Groups['body'].Value
+    $open = $body.IndexOf('$resultPlaceholder = [IO.File]::Open($resultPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)')
+    $bytes = $body.IndexOf('$resultPlaceholderBytes = [Text.UTF8Encoding]::new($false).GetBytes("{}`n")')
+    $write = $body.IndexOf('$resultPlaceholder.Write($resultPlaceholderBytes, 0, $resultPlaceholderBytes.Length)')
+    $flush = $body.IndexOf('$resultPlaceholder.Flush($true)')
+    $dispose = $body.IndexOf('$resultPlaceholder.Dispose()')
+    $launch = $body.IndexOf('$powershell = (Get-Command powershell.exe -ErrorAction Stop).Source')
+    Assert-CcodTrue ($open -ge 0 -and $bytes -gt $open -and $write -gt $bytes -and $flush -gt $write -and $dispose -gt $flush -and $launch -gt $dispose) 'owned nonempty result placeholder is written and flushed before the controller launch'
+}
+
 $results += Invoke-CcodTest 'timed out supervisor shutdown never terminates a reused PID' {
     $fake = New-CcodLifecycleFake
     $fake.World.WaitSupervisorExit = $false
@@ -1820,19 +1834,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.5.3 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.5.4 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.3' ([string]$package.version) 'package version is exactly 2.5.3'
+    Assert-CcodEqual '2.5.4' ([string]$package.version) 'package version is exactly 2.5.4'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.5.3-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.5.4-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.5.3-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.5.4-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 # Production mutation caught: allowing raw activation JSON to authorize Ready/Failed, checking the deadline after terminal processing, prompting without a strict validator child exit, or synchronously waiting on an unbounded validator.
@@ -2184,16 +2198,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.3-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.3-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.3-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.3-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/PersistenceIO.SelfTest.ps1
+++ b/tests/persistence/PersistenceIO.SelfTest.ps1
@@ -89,6 +89,31 @@ try {
         Assert-CcodEqual 'controller-result.json' $siblings[0].Name 'replacement leaves only the controller result file'
     }
 
+    Invoke-CcodTest 'atomically replaces a durable nonempty controller result placeholder accepted by a legacy writer' {
+        $path = Join-Path $root 'replace-nonempty\controller-result.json'
+        [IO.Directory]::CreateDirectory((Split-Path $path -Parent)) | Out-Null
+        $placeholder = [IO.File]::Open($path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+        try {
+            $placeholderBytes = [Text.UTF8Encoding]::new($false).GetBytes("{}`n")
+            $placeholder.Write($placeholderBytes, 0, $placeholderBytes.Length)
+            $placeholder.Flush($true)
+        } finally {
+            $placeholder.Dispose()
+        }
+
+        $legacyWriterBinding = {
+            param([Parameter(Mandatory)][byte[]]$Bytes)
+            return $Bytes.LongLength
+        }
+        Assert-CcodTrue ((Get-Item -LiteralPath $path).Length -gt 0) 'durable controller result placeholder is nonempty'
+        Assert-CcodEqual ([int64]3) (& $legacyWriterBinding ([IO.File]::ReadAllBytes($path))) 'legacy strict byte-array binding accepts the durable placeholder'
+        Write-CcodAtomicJson -Path $path -Value ([ordered]@{ schemaVersion = 1; action = 'Recover'; ok = $true })
+
+        $value = Read-CcodStrictJson -Path $path -ExpectedSchema 1 -Kind 'controller result'
+        Assert-CcodEqual 'Recover' $value.action 'replacement exposes the controller recovery action'
+        Assert-CcodEqual $true ([bool]$value.ok) 'replacement exposes the controller recovery result'
+    }
+
 
     Invoke-CcodTest 'uses the native handle commit without leftover siblings' {
         $path = Join-Path $root 'replace-native\settings.json'

--- a/tests/persistence/ReleaseWorkflow.SelfTest.ps1
+++ b/tests/persistence/ReleaseWorkflow.SelfTest.ps1
@@ -188,20 +188,20 @@ Invoke-CcodTest 'package scripts build provenance and workflows retain the relea
     Assert-CcodTrue ($release -cmatch '(?ms)^  publish:\r?\n    needs: build\r?\n    runs-on: windows-latest\r?\n    permissions:\r?\n      contents: write\s*$') 'only the publish job receives release-write permission'
 }
 
-Invoke-CcodTest '2.5.3 current documentation matches the lifecycle tray and uninstall contract' {
+Invoke-CcodTest '2.5.4 current documentation matches the lifecycle tray and uninstall contract' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.3' ([string]$package.version) 'package metadata is the 2.5.3 release'
+    Assert-CcodEqual '2.5.4' ([string]$package.version) 'package metadata is the 2.5.4 release'
 
     $changelog = Get-Content -LiteralPath (Join-Path $repositoryRoot 'CHANGELOG.md') -Raw
-    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.3\s*\r?\n(?<body>.*?)(?=^## |\z)')
-    Assert-CcodTrue $releaseSection.Success 'v2.5.3 release section exists'
+    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.4\s*\r?\n(?<body>.*?)(?=^## |\z)')
+    Assert-CcodTrue $releaseSection.Success 'v2.5.4 release section exists'
     $releaseBody = $releaseSection.Groups['body'].Value
-    Assert-CcodTrue ($releaseBody -match '(?m)^### English\s*$') 'v2.5.3 release section is English'
-    Assert-CcodTrue ($releaseBody.Contains('Fixed fail-closed uninstall recovery when its authenticated controller result placeholder is initially empty.')) 'v2.5.3 uninstall recovery release bullet is exact'
-    Assert-CcodTrue ($releaseBody.Contains('Added regression coverage for atomically replacing the empty preclaimed controller result file.')) 'v2.5.3 regression release bullet is exact'
+    Assert-CcodTrue ($releaseBody -match '(?m)^### English\s*$') 'v2.5.4 release section is English'
+    Assert-CcodTrue ($releaseBody.Contains('Made fail-closed uninstall recovery preclaim a durable nonempty controller result placeholder so it works with a still-manifest-sealed older controller runtime.')) 'v2.5.4 legacy controller compatibility release bullet is exact'
+    Assert-CcodTrue ($releaseBody.Contains('Added regression coverage for the legacy strict byte-array writer and the prelaunch placeholder ordering.')) 'v2.5.4 regression release bullet is exact'
 
     $readme = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.md') -Raw
-    Assert-CcodTrue ($readme.Contains('CodexRemote-fix-2.5.3-setup.exe')) 'English Quick Start names the 2.5.3 installer'
+    Assert-CcodTrue ($readme.Contains('CodexRemote-fix-2.5.4-setup.exe')) 'English Quick Start names the 2.5.4 installer'
     Assert-CcodTrue ($readme.Contains('## Connection and protection status')) 'English README documents the current status contract'
     foreach ($state in @('Waiting for Codex', 'Checking', 'Connected', 'Repair needed', 'Error', 'Running', 'Reconnecting', 'Stopping')) {
         Assert-CcodTrue ($readme.Contains($state)) "English README documents state: $state"
@@ -215,7 +215,7 @@ Invoke-CcodTest '2.5.3 current documentation matches the lifecycle tray and unin
     Assert-CcodTrue (-not $readme.Contains('Automation, Candidate-compatible trial, Logs, and Uninstall')) 'English README no longer describes removed tray toggles'
 
     $readmeZh = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.zh-CN.md') -Raw -Encoding UTF8
-    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.3-setup.exe')) 'Chinese Quick Start names the 2.5.3 installer'
+    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.4-setup.exe')) 'Chinese Quick Start names the 2.5.4 installer'
     Assert-CcodTrue ($readmeZh -match '## \u8FDE\u63A5\u4E0E\u5B88\u62A4\u72B6\u6001') 'Chinese README documents the current status contract'
     foreach ($statePattern in @('\u7B49\u5F85 Codex', '\u6B63\u5728\u68C0\u67E5', '\u5DF2\u8FDE\u63A5', '\u9700\u8981\u4FEE\u590D', '\u9519\u8BEF', '\u8FD0\u884C\u4E2D', '\u6B63\u5728\u91CD\u8FDE', '\u6B63\u5728\u505C\u6B62')) {
         Assert-CcodTrue ($readmeZh -match $statePattern) "Chinese README documents state pattern: $statePattern"

--- a/tests/persistence/TrayHostBuild.SelfTest.ps1
+++ b/tests/persistence/TrayHostBuild.SelfTest.ps1
@@ -4,14 +4,14 @@ $ErrorActionPreference='Stop'
 $repositoryRoot=Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $lockPath=Join-Path $repositoryRoot 'build\trayhost-packages.lock.json'
 
-Invoke-CcodTest '2.5.3 source metadata binds the package and TrayHost assembly identities' {
+Invoke-CcodTest '2.5.4 source metadata binds the package and TrayHost assembly identities' {
     $package=Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw|ConvertFrom-Json
-    Assert-CcodEqual '2.5.3' ([string]$package.version) 'package version is the 2.5.3 release version'
+    Assert-CcodEqual '2.5.4' ([string]$package.version) 'package version is the 2.5.4 release version'
     $assemblyInfo=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\AssemblyInfo.cs') -Raw
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.3\.0"\)') 'TrayHost assembly version is 2.5.3.0'
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.3\.0"\)') 'TrayHost file version is 2.5.3.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.4\.0"\)') 'TrayHost assembly version is 2.5.4.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.4\.0"\)') 'TrayHost file version is 2.5.4.0'
     $manifest=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\CodexRemote.TrayHost.manifest') -Raw
-    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.3\.0"') 'TrayHost manifest identity is 2.5.3.0'
+    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.4\.0"') 'TrayHost manifest identity is 2.5.4.0'
 }
 
 Invoke-CcodTest 'TrayHost build lock pins the Microsoft net48 reference package' {
@@ -48,14 +48,14 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
     Import-Module $modulePath -Force
     $artifact=Join-Path $env:TEMP ('ccod-trayhost-artifact-'+[Guid]::NewGuid().ToString('N'))
     try{
-        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.3' -OutputDirectory $artifact
+        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.4' -OutputDirectory $artifact
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe') -PathType Leaf) 'TrayHost executable exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe.config') -PathType Leaf) 'TrayHost config exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -PathType Leaf) 'TrayHost provenance exists'
         $provenance=Get-Content -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -Raw|ConvertFrom-Json
-        Assert-CcodEqual '2.5.3' ([string]$provenance.version) 'provenance version is exact'
+        Assert-CcodEqual '2.5.4' ([string]$provenance.version) 'provenance version is exact'
         $fileVersion=[Diagnostics.FileVersionInfo]::GetVersionInfo((Join-Path $artifact 'CodexRemote.TrayHost.exe')).FileVersion
-        Assert-CcodEqual '2.5.3.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
+        Assert-CcodEqual '2.5.4.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
         Assert-CcodTrue ([string]$provenance.gitCommit -cmatch '^[0-9a-f]{40}$') 'provenance records one canonical source commit'
         $provenanceTimestamp=[datetime]::MinValue
         Assert-CcodTrue ([datetime]::TryParse([string]$provenance.buildTimestampUtc,[Globalization.CultureInfo]::InvariantCulture,[Globalization.DateTimeStyles]::RoundtripKind,[ref]$provenanceTimestamp)) 'provenance records a parseable build timestamp'
@@ -67,10 +67,10 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
         Assert-CcodTrue (@($provenance.sourceFiles).Count -ge 10) 'provenance includes every TrayHost source'
         Assert-CcodTrue (-not ([string]$provenance|Select-String -Pattern '[A-Za-z]:\\|\\\\' -Quiet)) 'provenance does not leak absolute paths'
         $currentCommit=(& git -C $repositoryRoot rev-parse HEAD).Trim().ToLowerInvariant()
-        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.3' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
+        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.4' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
         Assert-CcodEqual $currentCommit ([string]$validated.GitCommit) 'artifact validation binds the current source commit when requested'
         $tampered=Join-Path $artifact 'CodexRemote.TrayHost.exe.config'; Add-Content -LiteralPath $tampered -Value 'x'
-        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.3' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
+        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.4' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
         Assert-CcodTrue $threw 'tampered artifact is rejected'
     }finally{if(Test-Path -LiteralPath $artifact){Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue}}
 }

--- a/tests/trayhost/TrayHostNativeSelfTest.cs
+++ b/tests/trayhost/TrayHostNativeSelfTest.cs
@@ -57,9 +57,9 @@ internal static class TrayHostNativeSelfTest
     private static PresentationSnapshot SnapshotV2(ulong revision)
     {
         string[] strings = new string[] {
-            "CodexRemote-fix 2.5.3", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
+            "CodexRemote-fix 2.5.4", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
             "Language / 语言", "Follow system (English)", "中文", "English", "Open logs", "About", "Exit",
-            "About", "CodexRemote-fix | Version 2.5.3", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
+            "About", "CodexRemote-fix | Version 2.5.4", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
         };
         return new PresentationSnapshot(revision, TrayColor.Green, ConnectionState.Connected, ProtectionState.Running, LanguageMode.English,
             PresentationFlags.LanguageEnabled | PresentationFlags.OpenLogsEnabled | PresentationFlags.AboutEnabled | PresentationFlags.ExitEnabled, strings);
@@ -147,7 +147,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform();
         TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         platform.TrackResult = 0; window.HandleContextMenu(new TrayPoint(0, 0));
-        AssertEqual("CodexRemote-fix 2.5.3|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
+        AssertEqual("CodexRemote-fix 2.5.4|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
         AssertTrue(!platform.AppendedText.Contains("Allow compatible update trials"), "candidate toggle is removed");
         AssertTrue(!platform.Commands.Contains(1009U), "tray uninstall command is removed");
         TrayCommand selected = TrayCommand.None; window.CommandSelected += delegate(TrayCommand command, ulong revision) { selected = command; };
@@ -163,7 +163,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform(); TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         window.ShowAbout();
         AssertTrue(platform.MessageBoxes.Count == 1, "verified About shows exactly one native message box");
-        AssertEqual("About|CodexRemote-fix | Version 2.5.3", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
+        AssertEqual("About|CodexRemote-fix | Version 2.5.4", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
         window.Dispose();
     }
 


### PR DESCRIPTION
## Summary\n- preclaim and durable-flush a nonempty controller result placeholder before launching a manifest-sealed legacy runtime controller\n- preserve CreateNew ownership and fail-closed recovery semantics\n- add regressions for strict legacy byte-array binding and launch ordering\n- bump release metadata and documentation to v2.5.4\n\n## Verification\n- npm test\n- npm run test:installed-lifecycle\n- npm run test:release-contract\n- powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests\\persistence\\UninstallBootstrap.SelfTest.ps1\n- powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests\\trayhost\\Invoke-TrayHostSelfTest.ps1 -ProductionOnly\n- independent uninstall payload closure review: GO\n\nThe live old-runtime uninstall retry remains intentionally deferred until the tagged v2.5.4 installer has been independently read back and validated.