### PR TITLE
fix: recover sealed legacy controller uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.5.5
+
+### English
+
+- Added a tightly scoped compatibility inspection for an older manifest-sealed controller that omitted its `ProcessControl` import. It accepts only the exact correlated legacy failure and requires a manifest-verified read-only ordinary-session recheck immediately before each protected uninstall deletion boundary.
+- New `SessionController` runtimes now load `ProcessControl` globally, and regression coverage rejects every other controller failure or changed compatibility proof.
+
+### 简体中文
+
+- 为遗漏 `ProcessControl` 导入的旧版清单封存 controller 增加了严格限定的兼容探测。它只接受精确关联的旧版失败特征，并在每个受保护卸载删除边界之前重新执行经清单验证的只读普通会话检查。
+- 新版 `SessionController` runtime 现会全局加载 `ProcessControl`；回归覆盖会拒绝其他任何 controller 失败或已变化的兼容性证明。
+
 ## v2.5.4
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.5.4-setup.exe` and `CodexRemote-fix-2.5.4-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
-2. Run `CodexRemote-fix-2.5.4-setup.exe`; no administrator rights are required.
+1. Download `CodexRemote-fix-2.5.5-setup.exe` and `CodexRemote-fix-2.5.5-setup.exe.sha256.txt` from the [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page, then verify the SHA-256.
+2. Run `CodexRemote-fix-2.5.5-setup.exe`; no administrator rights are required.
    Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 3. The tray supervisor starts automatically and creates the desktop shortcut **CodexRemote-fix**. Setup waits until the new runtime and TrayHost are ready, then offers **Restart now** or **Later**. Choose **Restart now** only when it is safe for Codex to close and relaunch into a repaired session; choose **Later** to leave the current Codex session untouched and resume safely after a later manual or normal Codex launch. When the connection reports **Connected**, open **Settings → Connections → Control other devices** to enroll or use the device.
 
@@ -62,6 +62,11 @@ upgrade.
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
 supervisor are working.
+
+## What's new in v2.5.5
+
+- Added a tightly scoped compatibility inspection for an older manifest-sealed controller that omitted its `ProcessControl` import. It accepts only the exact correlated legacy failure and requires a manifest-verified read-only ordinary-session recheck immediately before each protected uninstall deletion boundary.
+- New `SessionController` runtimes now load `ProcessControl` globally, and regression coverage rejects every other controller failure or changed compatibility proof.
 
 ## What's new in v2.5.4
 
@@ -167,8 +172,8 @@ The tray reports two independent, truthful status lines instead of inferring rea
 
 Every tagged release ships a Windows installer and its SHA-256 checksum as release assets.
 The `.github/workflows/release.yml` workflow builds the installer from the tag automatically,
-so the 2.5.4 release includes the ready-to-run `CodexRemote-fix-2.5.4-setup.exe`
-and `CodexRemote-fix-2.5.4-setup.exe.sha256.txt`.
+so the 2.5.5 release includes the ready-to-run `CodexRemote-fix-2.5.5-setup.exe`
+and `CodexRemote-fix-2.5.5-setup.exe.sha256.txt`.
 
 Each release appends a short English change summary to the GitHub release body. The README and
 [CHANGELOG.md](CHANGELOG.md) retain the bilingual documentation history.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.4-setup.exe` 和 `CodexRemote-fix-2.5.4-setup.exe.sha256.txt`，并核对 SHA-256。
-2. 运行 `CodexRemote-fix-2.5.4-setup.exe`，无需管理员权限。
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.5-setup.exe` 和 `CodexRemote-fix-2.5.5-setup.exe.sha256.txt`，并核对 SHA-256。
+2. 运行 `CodexRemote-fix-2.5.5-setup.exe`，无需管理员权限。
    Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 3. 托盘守护程序会自动启动，并创建桌面快捷方式 **CodexRemote-fix**。安装器会等待新 runtime 与 TrayHost 就绪，再让你选择 **立即重启** 或 **稍后**：仅在可以关闭并重新启动 Codex 时选择 **立即重启**；选择 **稍后** 会保持当前 Codex 会话不受影响，并会在之后手动或正常启动 Codex 时安全恢复。连接状态显示 **已连接** 后，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。
 
@@ -55,6 +55,11 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
+
+## v2.5.5 更新内容
+
+- 为遗漏 `ProcessControl` 导入的旧版清单封存 controller 增加了严格限定的兼容探测。它只接受精确关联的旧版失败特征，并在每个受保护卸载删除边界之前重新执行经清单验证的只读普通会话检查。
+- 新版 `SessionController` runtime 现会全局加载 `ProcessControl`；回归覆盖会拒绝其他任何 controller 失败或已变化的兼容性证明。
 
 ## v2.5.4 更新内容
 
@@ -159,9 +164,9 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 ## 发布（Releases）
 
 每个带 tag 的发布都会附带 Windows 安装包及其 SHA-256 校验文件。
-`.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此 2.5.4 发布提供
-可直接运行的 `CodexRemote-fix-2.5.4-setup.exe`
-及 `CodexRemote-fix-2.5.4-setup.exe.sha256.txt`。
+`.github/workflows/release.yml` 会在 tag 上自动构建安装包，因此 2.5.5 发布提供
+可直接运行的 `CodexRemote-fix-2.5.5-setup.exe`
+及 `CodexRemote-fix-2.5.5-setup.exe.sha256.txt`。
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/SessionController.ps1
+++ b/src/persistence/SessionController.ps1
@@ -33,6 +33,7 @@ Import-Module (Join-Path $controllerModuleRoot 'LifecycleEpoch.psm1') -Force
 Import-Module (Join-Path $controllerModuleRoot 'TransitionJournal.psm1') -Force
 Import-Module (Join-Path $controllerModuleRoot 'KernelObjects.psm1') -Force
 Import-Module (Join-Path $controllerModuleRoot 'PersistenceIO.psm1') -Force -Global
+Import-Module (Join-Path $controllerModuleRoot 'ProcessControl.psm1') -Force -Global
 
 function Test-CcodControllerCanonicalGuid([object]$Value){
     if($Value -isnot [string]){return $false}

--- a/src/persistence/modules/InstallLifecycle.psm1
+++ b/src/persistence/modules/InstallLifecycle.psm1
@@ -52,6 +52,18 @@ function Test-CcodLifecycleCanonicalGuid {
     return $Value -is [string] -and [guid]::TryParseExact($Value, 'D', [ref]$parsed) -and $parsed.ToString('D') -ceq $Value
 }
 
+function Test-CcodLifecycleExactProperties {
+    param($Value, [string[]]$Expected)
+
+    if ($null -eq $Value -or ($Value -isnot [pscustomobject] -and $Value -isnot [Collections.IDictionary])) { return $false }
+    $actual = if ($Value -is [Collections.IDictionary]) { @($Value.Keys) } else { @($Value.PSObject.Properties.Name) }
+    if ($actual.Count -ne $Expected.Count) { return $false }
+    foreach ($name in $Expected) {
+        if ($actual -cnotcontains $name) { return $false }
+    }
+    return $true
+}
+
 function Assert-CcodActivationReceipt {
     param($Receipt)
     if (-not (Test-CcodActivationExactProperties $Receipt) -or
@@ -730,6 +742,42 @@ function Stop-CcodLifecycleExactProcess {
     return ($forcedExit -is [bool] -and $forcedExit)
 }
 
+function Test-CcodLifecycleLegacyControllerProcessControlFailure {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)]$Request,
+        [Parameter(Mandatory)][int]$ExitCode,
+        [Parameter(Mandatory)][string]$ControllerPath
+    )
+
+    try {
+        $resultFields = @('schemaVersion','action','ok','outcome','safeState','stage','transactionId','package','source','special','probes','recovery','error','logFile')
+        $errorFields = @('code','stage','message')
+        if ($ExitCode -ne 1 -or
+            -not (Test-CcodLifecycleExactProperties $Result $resultFields) -or
+            ($Result.schemaVersion -isnot [int] -and $Result.schemaVersion -isnot [long]) -or $Result.schemaVersion -ne 1 -or
+            $Result.action -cne 'Recover' -or $Result.ok -isnot [bool] -or $Result.ok -or
+            $Result.outcome -cne 'Error' -or $Result.safeState -cne 'Error' -or $Result.stage -cne 'InputValidation' -or
+            $Result.transactionId -cne $Request.transactionId -or $Result.package -ne $null -or $Result.source -ne $null -or
+            $Result.special -ne $null -or $Result.probes -ne $null -or $Result.recovery -ne $null -or $Result.logFile -ne $null -or
+            -not (Test-CcodLifecycleExactProperties $Result.error $errorFields) -or
+            $Result.error.code -cne 'CCOD_REQUEST_INVALID' -or $Result.error.stage -cne 'InputValidation' -or
+            $Result.error.message -cne 'The session controller failed safely. See the session log for details.' -or
+            $Request.schemaVersion -ne 1 -or $Request.action -cne 'Recover' -or
+            -not (Test-CcodLifecycleCanonicalGuid $Request.transactionId) -or
+            $ControllerPath -isnot [string] -or -not [IO.File]::Exists($ControllerPath)) {
+            return $false
+        }
+
+        $controllerText = [IO.File]::ReadAllText($ControllerPath, [Text.UTF8Encoding]::new($false))
+        $legacyLookup = $controllerText -match '(?im)^\s*\$module\s*=\s*Get-Module\s+ProcessControl\s+-ErrorAction\s+Stop\s*$'
+        $processControlImport = $controllerText -match '(?im)^\s*Import-Module\s+.*ProcessControl\.psm1'
+        return [bool]($legacyLookup -and -not $processControlImport)
+    } catch {
+        return $false
+    }
+}
+
 function Invoke-CcodLifecycleControllerRecover {
     param(
         [Parameter(Mandatory)][string]$InstallRoot,
@@ -798,8 +846,13 @@ function Invoke-CcodLifecycleControllerRecover {
             Throw-CcodLifecycleError 'CCOD_UNINSTALL_NORMALIZATION_FAILED' 'The controller returned invalid JSON' $resultPath
         }
         if (($fromStdout | ConvertTo-Json -Depth 16 -Compress) -cne ($result | ConvertTo-Json -Depth 16 -Compress) -or
-            $result.transactionId -cne $request.transactionId -or $result.action -cne 'Recover' -or
-            $exitCode -ne 0 -or $result.ok -ne $true -or $null -ne $result.error) {
+            $result.transactionId -cne $request.transactionId -or $result.action -cne 'Recover') {
+            Throw-CcodLifecycleError 'CCOD_UNINSTALL_NORMALIZATION_FAILED' 'The controller could not normalize the session safely' $result
+        }
+        if ($exitCode -ne 0 -or $result.ok -ne $true -or $null -ne $result.error) {
+            if (Test-CcodLifecycleLegacyControllerProcessControlFailure -Result $result -Request $request -ExitCode $exitCode -ControllerPath $controller) {
+                Throw-CcodLifecycleError 'CCOD_UNINSTALL_LEGACY_CONTROLLER_PROCESSCONTROL_COMPATIBILITY' 'The active legacy controller requires an authenticated compatibility inspection' $result
+            }
             Throw-CcodLifecycleError 'CCOD_UNINSTALL_NORMALIZATION_FAILED' 'The controller could not normalize the session safely' $result
         }
         $specialPresent = $null -ne $result.special -and
@@ -816,6 +869,116 @@ function Invoke-CcodLifecycleControllerRecover {
         foreach ($path in @($requestPath, $resultPath, $stderrPath)) {
             if ([IO.File]::Exists($path)) { try { [IO.File]::Delete($path) } catch { } }
         }
+    }
+}
+
+function Assert-CcodLifecycleLegacyNoSpecialState {
+    param([Parameter(Mandatory)][string]$InstallRoot)
+
+    $stateRoot = [IO.Path]::GetFullPath((Join-Path $InstallRoot 'state'))
+    $status = Read-CcodStatus -StateRoot $stateRoot
+    if (-not (Test-CcodLifecycleExactProperties $status @('schemaVersion','session')) -or
+        ($status.schemaVersion -isnot [int] -and $status.schemaVersion -isnot [long]) -or
+        $status.schemaVersion -ne 1 -or $null -ne $status.session) {
+        Throw-CcodLifecycleError 'CCOD_UNINSTALL_LEGACY_COMPATIBILITY_STATE_INVALID' 'Legacy compatibility requires a strict no-session status state' $status
+    }
+
+    $transitionPath = [IO.Path]::GetFullPath((Join-Path $stateRoot 'transition.json'))
+    $transition = Read-CcodStrictJson -Path $transitionPath -ExpectedSchema 1 -Kind 'transition'
+    if (-not (Test-CcodLifecycleExactProperties $transition @('schemaVersion','activeTransaction')) -or
+        ($transition.schemaVersion -isnot [int] -and $transition.schemaVersion -isnot [long]) -or
+        $transition.schemaVersion -ne 1 -or $null -ne $transition.activeTransaction) {
+        Throw-CcodLifecycleError 'CCOD_UNINSTALL_LEGACY_COMPATIBILITY_STATE_INVALID' 'Legacy compatibility requires an empty transition journal' $transition
+    }
+
+    if ($null -ne (Read-CcodLifecycleRequest -StateRoot $stateRoot)) {
+        Throw-CcodLifecycleError 'CCOD_UNINSTALL_LEGACY_COMPATIBILITY_STATE_INVALID' 'Legacy compatibility refuses a pending lifecycle request' $stateRoot
+    }
+}
+
+function Test-CcodLifecycleLegacyInspectionResult {
+    param(
+        [Parameter(Mandatory)]$Result,
+        [Parameter(Mandatory)][string]$TransactionId
+    )
+
+    $fields = @('schemaVersion','action','ok','outcome','safeState','stage','transactionId','package','source','special','probes','recovery','error','logFile')
+    return (Test-CcodLifecycleExactProperties $Result $fields) -and
+        ($Result.schemaVersion -is [int] -or $Result.schemaVersion -is [long]) -and $Result.schemaVersion -eq 1 -and
+        $Result.action -ceq 'Inspect' -and $Result.ok -is [bool] -and $Result.ok -and
+        $Result.outcome -ceq 'Inspected' -and @('NoCodex','OrdinaryRunning') -ccontains $Result.safeState -and
+        $Result.stage -ceq 'Inspected' -and $Result.transactionId -ceq $TransactionId -and
+        $null -eq $Result.special -and $null -eq $Result.error
+}
+
+function Invoke-CcodLifecycleLegacyControllerCompatibilityInspection {
+    param(
+        [Parameter(Mandatory)][string]$InstallRoot,
+        [Parameter(Mandatory)][string]$RuntimeId,
+        [Parameter(Mandatory)]$Identity,
+        [Parameter(Mandatory)]$Transaction
+    )
+
+    try {
+        if ($Identity.UserSid -isnot [string] -or [string]::IsNullOrWhiteSpace($Identity.UserSid) -or
+            $Identity.SessionId -isnot [int] -or $Identity.SessionId -lt 0 -or
+            $Transaction.runtimeGeneration -isnot [ValueType] -or $Transaction.leaseEpoch -isnot [ValueType]) {
+            throw 'identity or transaction context is invalid'
+        }
+        [uint64]$runtimeGeneration = $Transaction.runtimeGeneration
+        [uint64]$leaseEpoch = $Transaction.leaseEpoch
+        $root = Get-CcodLifecycleCanonicalRoot -Path $InstallRoot -Kind 'Install root'
+        $runtimeRoot = [IO.Path]::GetFullPath((Join-Path (Join-Path $root 'runtime') $RuntimeId))
+        $validation = Test-CcodRuntimeManifest -RuntimeDirectory $runtimeRoot -ExpectedRuntimeId $RuntimeId
+        if (-not $validation.Valid) { throw 'active runtime manifest is invalid' }
+        $controller = [IO.Path]::GetFullPath((Join-Path $runtimeRoot 'src\persistence\SessionController.ps1'))
+        if (-not [IO.File]::Exists($controller)) { throw 'active controller is missing' }
+
+        Assert-CcodLifecycleLegacyNoSpecialState -InstallRoot $root
+        $inspectionId = [guid]::NewGuid().ToString('D')
+        $controllerLiteral = "'" + $controller.Replace("'", "''") + "'"
+        $rootLiteral = "'" + $root.Replace("'", "''") + "'"
+        $runtimeLiteral = "'" + $RuntimeId.Replace("'", "''") + "'"
+        $inspectionLiteral = "'" + $inspectionId + "'"
+        $probeScript = @"
+`$ErrorActionPreference = 'Stop'
+`$WarningPreference = 'SilentlyContinue'
+`$InformationPreference = 'SilentlyContinue'
+`$ProgressPreference = 'SilentlyContinue'
+`$controller = [IO.Path]::GetFullPath($controllerLiteral)
+. `$controller
+`$current = [Diagnostics.Process]::GetCurrentProcess()
+try {
+    `$created = `$current.StartTime.ToUniversalTime().ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+    `$identity = [pscustomobject][ordered]@{ pid = [int]`$current.Id; creationTimeUtc = `$created; sessionId = [string]`$current.SessionId }
+} finally {
+    `$current.Dispose()
+}
+`$context = Resolve-CcodControllerRuntime -InstallRoot $rootLiteral -ControllerPath `$controller
+`$request = New-CcodManualControllerRequest -Action 'Inspect' -RuntimeId $runtimeLiteral -RuntimeGeneration ([UInt64]$runtimeGeneration) -LeaseEpoch ([UInt64]$leaseEpoch) -OwnerIdentity ([pscustomobject][ordered]@{ pid = `$identity.pid; creationTimeUtc = `$identity.creationTimeUtc }) -SupervisorIdentity `$identity -ExistingOnly `$true -RendererPort `$null -MainPort `$null -TimeoutMilliseconds 5000 -RestartOrdinary `$true -TransactionId $inspectionLiteral
+`$paths = Get-CcodInstalledControllerPaths -RuntimeContext `$context
+`$result = Invoke-CcodInspectSession -Request `$request -Paths `$paths -Adapters @{}
+[Console]::Out.WriteLine((`$result | ConvertTo-Json -Depth 16 -Compress))
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($probeScript))
+        $powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
+        $output = @(& $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1)
+        $exitCode = $LASTEXITCODE
+        $lines = @($output | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($exitCode -ne 0 -or $lines.Count -ne 1) { throw 'compatibility inspection did not return one successful result' }
+        $inspection = $lines[0] | ConvertFrom-Json -ErrorAction Stop
+        if (-not (Test-CcodLifecycleLegacyInspectionResult -Result $inspection -TransactionId $inspectionId)) {
+            throw 'compatibility inspection result is invalid or unsafe'
+        }
+        Assert-CcodLifecycleLegacyNoSpecialState -InstallRoot $root
+        return [pscustomobject][ordered]@{
+            SchemaVersion = 1
+            SpecialPresent = $false
+            Normalized = $true
+            Outcome = 'LegacyNoSpecialCompatibility'
+        }
+    } catch {
+        Throw-CcodLifecycleError 'CCOD_UNINSTALL_LEGACY_COMPATIBILITY_FAILED' 'The legacy controller compatibility inspection could not prove an ordinary session' $InstallRoot
     }
 }
 
@@ -1081,6 +1244,16 @@ function Get-CcodLifecycleAdapters {
         NormalizeSpecialSession = {
             param($InstallRoot, $RuntimeId, $Identity)
             Invoke-CcodLifecycleControllerRecover -InstallRoot $InstallRoot -RuntimeId $RuntimeId -Identity $Identity
+        }
+        NormalizeLegacyControllerCompatibility = {
+            param($InstallRoot, $RuntimeId, $Identity, $Transaction)
+            Invoke-CcodLifecycleLegacyControllerCompatibilityInspection -InstallRoot $InstallRoot -RuntimeId $RuntimeId -Identity $Identity -Transaction $Transaction
+        }
+        VerifyLegacyControllerCompatibility = {
+            param($InstallRoot, $RuntimeId, $Identity, $Transaction)
+            $receipt = Invoke-CcodLifecycleLegacyControllerCompatibilityInspection -InstallRoot $InstallRoot -RuntimeId $RuntimeId -Identity $Identity -Transaction $Transaction
+            return $receipt.SpecialPresent -is [bool] -and -not $receipt.SpecialPresent -and
+                $receipt.Normalized -is [bool] -and $receipt.Normalized -and $receipt.Outcome -ceq 'LegacyNoSpecialCompatibility'
         }
         SetAutomationEnabled = {
             param($StateRoot, $Enabled)
@@ -1748,6 +1921,19 @@ function Invoke-CcodUninstallCleanup {
             Set-CcodUninstallTransactionPhase -Transaction $Transaction -Phase 'Recovering' -WriteTransaction $WriteTransaction -Adapters $adapters
             try {
                 $recovery = & $adapters.NormalizeSpecialSession $root $pointer.activeRuntime $identity
+            } catch {
+                $normalizationFailure = $_
+                if ((Get-CcodLifecycleErrorId $normalizationFailure) -ceq 'CCOD_UNINSTALL_LEGACY_CONTROLLER_PROCESSCONTROL_COMPATIBILITY') {
+                    try {
+                        $recovery = & $adapters.NormalizeLegacyControllerCompatibility $root $pointer.activeRuntime $identity $Transaction
+                    } catch {
+                        Throw-CcodLifecycleError 'CCOD_UNINSTALL_RECOVERY_FAILED' 'A special Codex session could not be recovered before uninstall' $Transaction
+                    }
+                } else {
+                    Throw-CcodLifecycleError 'CCOD_UNINSTALL_RECOVERY_FAILED' 'A special Codex session could not be recovered before uninstall' $Transaction
+                }
+            }
+            try {
                 if ($null -eq $recovery -or $null -eq $recovery.PSObject.Properties['SpecialPresent'] -or $recovery.SpecialPresent -isnot [bool] -or
                     $null -eq $recovery.PSObject.Properties['Normalized'] -or $recovery.Normalized -isnot [bool] -or
                     ([bool]$recovery.SpecialPresent -and -not [bool]$recovery.Normalized)) {
@@ -1782,6 +1968,8 @@ function Invoke-CcodUninstallCleanup {
 
         if ($phase -eq 'ProtectionStopped') {
             try {
+                $compatibilityVerified = & $adapters.VerifyLegacyControllerCompatibility $root $pointer.activeRuntime $identity $Transaction
+                if ($compatibilityVerified -isnot [bool] -or -not $compatibilityVerified) { throw 'manifest-verified no-special proof changed before task removal' }
                 & $adapters.RemoveSupervisorTask
                 $absent = & $adapters.TestSupervisorTaskAbsent
                 if ($absent -isnot [bool] -or -not $absent) { throw 'scheduled task deletion was not proven' }
@@ -1795,7 +1983,13 @@ function Invoke-CcodUninstallCleanup {
         }
 
         if ($phase -eq 'TaskRemoved') {
-            try { Remove-CcodLifecycleInstallTree -InstallRoot $root -Adapters $adapters }
+            try {
+                if ([IO.Directory]::Exists($root)) {
+                    $compatibilityVerified = & $adapters.VerifyLegacyControllerCompatibility $root $Transaction.runtimeId $identity $Transaction
+                    if ($compatibilityVerified -isnot [bool] -or -not $compatibilityVerified) { throw 'manifest-verified no-special proof changed before application removal' }
+                }
+                Remove-CcodLifecycleInstallTree -InstallRoot $root -Adapters $adapters
+            }
             catch { Throw-CcodLifecycleError 'CCOD_UNINSTALL_APPLICATION_STATE_REMOVAL_FAILED' 'The application runtime and state could not be removed safely' $Transaction }
             Set-CcodUninstallTransactionPhase -Transaction $Transaction -Phase 'ApplicationStateRemoved' -WriteTransaction $WriteTransaction -Adapters $adapters
             Set-CcodUninstallTransactionPhase -Transaction $Transaction -Phase 'ReadyForInno' -WriteTransaction $WriteTransaction -Adapters $adapters

--- a/src/trayhost/AssemblyInfo.cs
+++ b/src/trayhost/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Persistent native tray host for CodexRemote-fix")]
 [assembly: AssemblyCompany("CodexRemote-fix contributors")]
 [assembly: AssemblyProduct("CodexRemote-fix")]
-[assembly: AssemblyVersion("2.5.4.0")]
-[assembly: AssemblyFileVersion("2.5.4.0")]
+[assembly: AssemblyVersion("2.5.5.0")]
+[assembly: AssemblyFileVersion("2.5.5.0")]
 [assembly: ComVisible(false)]

--- a/src/trayhost/CodexRemote.TrayHost.manifest
+++ b/src/trayhost/CodexRemote.TrayHost.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.5.4.0" name="CodexRemote.fix.TrayHost" type="win32" />
+  <assemblyIdentity version="2.5.5.0" name="CodexRemote.fix.TrayHost" type="win32" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -126,6 +126,10 @@ function New-CcodLifecycleFake {
         SupervisorAbsenceChecks = 0
         NormalizeReceipt = New-CcodLifecycleNormalizeReceipt -SpecialPresent $false -Normalized $false
         NormalizeCalls = 0
+        LegacyCompatibilityReceipt = New-CcodLifecycleNormalizeReceipt -SpecialPresent $false -Normalized $true -Outcome 'LegacyNoSpecialCompatibility'
+        LegacyCompatibilityCalls = 0
+        LegacyCompatibilityVerifyCalls = 0
+        LegacyCompatibilityVerified = $true
         KeyPath = $null
         BackupCalls = 0
         RemoveKeyCalls = 0
@@ -226,6 +230,8 @@ function New-CcodLifecycleFake {
         $world.ShutdownGateClosed++
     }.GetNewClosure()
     $adapters.NormalizeSpecialSession = { param($InstallRoot, $RuntimeId, $Identity) $world.Calls.Add("Normalize:$RuntimeId"); $world.NormalizeCalls++; $world.NormalizeReceipt }.GetNewClosure()
+    $adapters.NormalizeLegacyControllerCompatibility = { param($InstallRoot, $RuntimeId, $Identity, $Transaction) $world.Calls.Add("LegacyCompatibility:$RuntimeId"); $world.LegacyCompatibilityCalls++; $world.LegacyCompatibilityReceipt }.GetNewClosure()
+    $adapters.VerifyLegacyControllerCompatibility = { param($InstallRoot, $RuntimeId, $Identity, $Transaction) $world.Calls.Add("VerifyLegacyCompatibility:$RuntimeId"); $world.LegacyCompatibilityVerifyCalls++; [bool]$world.LegacyCompatibilityVerified }.GetNewClosure()
     $adapters.SetAutomationEnabled = { param($StateRoot, $Enabled) $world.Calls.Add("Automation:$Enabled"); $world.AutomationPaused++ }.GetNewClosure()
     $adapters.EnterTransitionLease = { param($UserSid, $SessionId) $world.Calls.Add("EnterTransitionLease"); $world.TransitionLeaseCalls++; [pscustomobject][ordered]@{ SchemaVersion = 1; Name = "Fake-Transition"; Kind = 'Transition'; Outcome = 'Acquired'; CreatedNew = $false; Abandoned = $false; Handle = [pscustomobject]@{ Kind = 'Mutex' }; OwnerManagedThreadId = [Threading.Thread]::CurrentThread.ManagedThreadId; Released = $false } }.GetNewClosure()
     $adapters.ExitTransitionLease = { param($Lease) $world.Calls.Add('ExitTransitionLease'); $true }.GetNewClosure()
@@ -1289,6 +1295,134 @@ $results += Invoke-CcodTest 'transactional uninstall reaches ReadyForInno only a
     }
 }
 
+$results += Invoke-CcodTest 'legacy controller compatibility recognizes only the sealed missing-ProcessControl input-validation signature' {
+    $controller = Join-Path (New-CcodLifecycleTempRoot) 'SessionController.ps1'
+    try {
+        [IO.Directory]::CreateDirectory((Split-Path $controller -Parent)) | Out-Null
+        [IO.File]::WriteAllText($controller, @'
+$module = Get-Module ProcessControl -ErrorAction Stop
+'@, [Text.UTF8Encoding]::new($false))
+        $request = [pscustomobject][ordered]@{
+            schemaVersion = 1; action = 'Recover'; transactionId = '33333333-4444-4555-8666-777777777777'; runtimeId = 'runtime-legacy'
+        }
+        $result = [pscustomobject][ordered]@{
+            schemaVersion = 1; action = 'Recover'; ok = $false; outcome = 'Error'; safeState = 'Error'; stage = 'InputValidation'
+            transactionId = $request.transactionId; package = $null; source = $null; special = $null; probes = $null; recovery = $null
+            error = [pscustomobject][ordered]@{ code = 'CCOD_REQUEST_INVALID'; stage = 'InputValidation'; message = 'The session controller failed safely. See the session log for details.' }
+            logFile = $null
+        }
+        $module = Get-Module InstallLifecycle -ErrorAction Stop
+        $recognized = & $module { param($Value,$RequestValue,$Path) Test-CcodLifecycleLegacyControllerProcessControlFailure -Result $Value -Request $RequestValue -ExitCode 1 -ControllerPath $Path } $result $request $controller
+        Assert-CcodEqual $true $recognized 'only the known sealed missing-import controller shape enters compatibility'
+        Add-Content -LiteralPath $controller -Value "Import-Module (Join-Path `$controllerModuleRoot 'ProcessControl.psm1') -Force -Global" -Encoding utf8
+        $recognizedWithImport = & $module { param($Value,$RequestValue,$Path) Test-CcodLifecycleLegacyControllerProcessControlFailure -Result $Value -Request $RequestValue -ExitCode 1 -ControllerPath $Path } $result $request $controller
+        Assert-CcodEqual $false $recognizedWithImport 'a controller that imports ProcessControl cannot take the compatibility branch'
+        $result.error.code = 'CCOD_CONTROLLER_ENGINE_RESULT_INVALID'
+        $wrongError = & $module { param($Value,$RequestValue,$Path) Test-CcodLifecycleLegacyControllerProcessControlFailure -Result $Value -Request $RequestValue -ExitCode 1 -ControllerPath $Path } $result $request $controller
+        Assert-CcodEqual $false $wrongError 'other controller failures cannot masquerade as legacy compatibility'
+    } finally {
+        $root = Split-Path $controller -Parent
+        if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force }
+    }
+}
+
+$results += Invoke-CcodTest 'legacy controller compatibility keeps strict recovery, supervisor, tray, and task proofs before deletion' {
+    $source = New-CcodLifecycleTempRoot
+    $install = New-CcodLifecycleTempRoot
+    $nodeRoot = New-CcodLifecycleTempRoot
+    try {
+        New-CcodLifecycleSourceFixture -Root $source | Out-Null
+        $nodePath = New-CcodLifecycleFakeNode -Root $nodeRoot
+        Invoke-CcodInstall -SourceRoot $source -InstallRoot $install -Adapters (New-CcodLifecycleFake -NodePath $nodePath).Adapters | Out-Null
+        $fake = New-CcodLifecycleFake -NodePath $nodePath
+        $fake.Adapters.NormalizeSpecialSession = {
+            param($InstallRoot,$RuntimeId,$Identity)
+            $exception = [InvalidOperationException]::new('legacy ProcessControl import is absent')
+            throw [Management.Automation.ErrorRecord]::new($exception, 'CCOD_UNINSTALL_LEGACY_CONTROLLER_PROCESSCONTROL_COMPATIBILITY', [Management.Automation.ErrorCategory]::InvalidData, $RuntimeId)
+        }
+        $transaction = New-CcodLifecycleUninstallTransaction -InstallRoot $install -Fake $fake
+        $receipt = Invoke-CcodLifecycleUninstallCleanupTest -InstallRoot $install -Transaction $transaction -Adapters $fake.Adapters
+        Assert-CcodEqual 'ReadyForInno' $receipt.Result.phase 'the independently inspected ordinary state may reach the native Inno handoff'
+        Assert-CcodEqual 1 $fake.World.LegacyCompatibilityCalls 'compatibility inspection is entered only after the exact legacy failure'
+        Assert-CcodEqual 2 $fake.World.LegacyCompatibilityVerifyCalls 'ordinary state is rechecked before both protected deletion boundaries'
+        Assert-CcodEqual 2 $fake.World.SupervisorAbsenceChecks 'compatibility never bypasses the strict Supervisor-absence proof'
+        Assert-CcodEqual 1 $fake.World.TaskRemoved 'task deletion still follows the compatibility verification'
+        Assert-CcodTrue (-not (Test-Path -LiteralPath $install)) 'application deletion remains downstream of every proof'
+    } finally {
+        foreach ($path in @($source,$install,$nodeRoot)) { if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Recurse -Force } }
+    }
+}
+
+$results += Invoke-CcodTest 'legacy compatibility fails closed for every non-matching controller error or changed ordinary-state proof' {
+    foreach ($case in @(
+        [pscustomobject]@{ Name='nonmatching controller failure'; Code='CCOD_UNINSTALL_NORMALIZATION_FAILED'; Verify=$true; Expected='CCOD_UNINSTALL_RECOVERY_FAILED'; CompatibilityCalls=0; VerifyCalls=0 },
+        [pscustomobject]@{ Name='pre-task ordinary-state proof changed'; Code='CCOD_UNINSTALL_LEGACY_CONTROLLER_PROCESSCONTROL_COMPATIBILITY'; Verify=$false; Expected='CCOD_UNINSTALL_TASK_REMOVAL_FAILED'; CompatibilityCalls=1; VerifyCalls=1 }
+    )) {
+        $source = New-CcodLifecycleTempRoot
+        $install = New-CcodLifecycleTempRoot
+        $nodeRoot = New-CcodLifecycleTempRoot
+        try {
+            New-CcodLifecycleSourceFixture -Root $source | Out-Null
+            $nodePath = New-CcodLifecycleFakeNode -Root $nodeRoot
+            Invoke-CcodInstall -SourceRoot $source -InstallRoot $install -Adapters (New-CcodLifecycleFake -NodePath $nodePath).Adapters | Out-Null
+            $fake = New-CcodLifecycleFake -NodePath $nodePath
+            $fake.World.LegacyCompatibilityVerified = [bool]$case.Verify
+            $fake.Adapters.NormalizeSpecialSession = {
+                param($InstallRoot,$RuntimeId,$Identity)
+                $exception = [InvalidOperationException]::new('controller recovery failed')
+                throw [Management.Automation.ErrorRecord]::new($exception, $case.Code, [Management.Automation.ErrorCategory]::InvalidData, $RuntimeId)
+            }.GetNewClosure()
+            $transaction = New-CcodLifecycleUninstallTransaction -InstallRoot $install -Fake $fake
+            Assert-CcodThrows { Invoke-CcodLifecycleUninstallCleanupTest -InstallRoot $install -Transaction $transaction -Adapters $fake.Adapters } $case.Expected
+            Assert-CcodEqual $case.CompatibilityCalls $fake.World.LegacyCompatibilityCalls "$($case.Name) has the exact compatibility entry count"
+            Assert-CcodEqual $case.VerifyCalls $fake.World.LegacyCompatibilityVerifyCalls "$($case.Name) has the exact compatibility recheck count"
+            Assert-CcodEqual 0 $fake.World.TaskRemoved "$($case.Name) cannot delete the scheduled task"
+            Assert-CcodTrue (Test-Path -LiteralPath $install) "$($case.Name) keeps the application tree intact"
+        } finally {
+            foreach ($path in @($source,$install,$nodeRoot)) { if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Recurse -Force } }
+        }
+    }
+}
+
+$results += Invoke-CcodTest 'legacy compatibility rechecks a resumed transaction before every remaining deletion boundary' {
+    $source = New-CcodLifecycleTempRoot
+    $install = New-CcodLifecycleTempRoot
+    $nodeRoot = New-CcodLifecycleTempRoot
+    try {
+        New-CcodLifecycleSourceFixture -Root $source | Out-Null
+        $nodePath = New-CcodLifecycleFakeNode -Root $nodeRoot
+        Invoke-CcodInstall -SourceRoot $source -InstallRoot $install -Adapters (New-CcodLifecycleFake -NodePath $nodePath).Adapters | Out-Null
+        $fake = New-CcodLifecycleFake -NodePath $nodePath
+        $fake.Adapters.NormalizeSpecialSession = {
+            param($InstallRoot,$RuntimeId,$Identity)
+            $exception = [InvalidOperationException]::new('legacy ProcessControl import is absent')
+            throw [Management.Automation.ErrorRecord]::new($exception, 'CCOD_UNINSTALL_LEGACY_CONTROLLER_PROCESSCONTROL_COMPATIBILITY', [Management.Automation.ErrorCategory]::InvalidData, $RuntimeId)
+        }
+        $proof = [pscustomobject]@{ Calls = 0 }
+        $fake.Adapters.VerifyLegacyControllerCompatibility = {
+            param($InstallRoot,$RuntimeId,$Identity,$Transaction)
+            $proof.Calls++
+            $fake.World.LegacyCompatibilityVerifyCalls++
+            return ($proof.Calls -gt 1)
+        }.GetNewClosure()
+        $transaction = New-CcodLifecycleUninstallTransaction -InstallRoot $install -Fake $fake
+        Assert-CcodThrows { Invoke-CcodLifecycleUninstallCleanupTest -InstallRoot $install -Transaction $transaction -Adapters $fake.Adapters } 'CCOD_UNINSTALL_TASK_REMOVAL_FAILED'
+        Assert-CcodEqual 'ProtectionStopped' $transaction.phase 'failed pre-task proof leaves the transaction before task deletion'
+        Assert-CcodEqual 0 $fake.World.TaskRemoved 'failed pre-task proof does not remove the scheduled task'
+        $transaction.phase = 'Failed'
+        $transaction.resumePhase = 'ProtectionStopped'
+        $transaction.errorCode = 'CCOD_UNINSTALL_TASK_REMOVAL_FAILED'
+        $receipt = Invoke-CcodLifecycleUninstallCleanupTest -InstallRoot $install -Transaction $transaction -Adapters $fake.Adapters
+        Assert-CcodEqual 'ReadyForInno' $receipt.Result.phase 'the resumed transaction reaches the native Inno handoff only after fresh proofs'
+        Assert-CcodEqual 1 $fake.World.LegacyCompatibilityCalls 'resume does not rerun the legacy fallback normalization'
+        Assert-CcodEqual 3 $fake.World.LegacyCompatibilityVerifyCalls 'failed then resumed cleanup proves state before both remaining deletion boundaries'
+        Assert-CcodEqual 1 $fake.World.TaskRemoved 'the task is removed only after the resumed fresh proof'
+        Assert-CcodTrue (-not (Test-Path -LiteralPath $install)) 'the application tree is removed only after the resumed fresh proof'
+    } finally {
+        foreach ($path in @($source,$install,$nodeRoot)) { if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Recurse -Force } }
+    }
+}
+
 $results += Invoke-CcodTest 'transactional uninstall fails closed before recovery when the transition lease is unavailable' {
     $source = New-CcodLifecycleTempRoot
     $install = New-CcodLifecycleTempRoot
@@ -1486,7 +1620,7 @@ $results += Invoke-CcodTest 'transactional uninstall refuses application deletio
     }
 }
 
-$results += Invoke-CcodTest 'transactional uninstall resumes partial application deletion after the active pointer is already gone' {
+$results += Invoke-CcodTest 'transactional uninstall refuses partial application deletion when the active pointer is already gone' {
     $source = New-CcodLifecycleTempRoot
     $install = New-CcodLifecycleTempRoot
     $nodeRoot = New-CcodLifecycleTempRoot
@@ -1499,12 +1633,12 @@ $results += Invoke-CcodTest 'transactional uninstall resumes partial application
         $fake2 = New-CcodLifecycleFake -NodePath $nodePath
         $transaction = New-CcodLifecycleUninstallTransaction -InstallRoot $install -Fake $fake2 -Phase 'TaskRemoved'
         [IO.File]::Delete((Join-Path $install 'active.json'))
-        $receipt = Invoke-CcodLifecycleUninstallCleanupTest -InstallRoot $install -Transaction $transaction -Adapters $fake2.Adapters
-        Assert-CcodEqual 'ReadyForInno' $receipt.Result.phase 'partial deletion retry reaches the Inno handoff phase'
-        Assert-CcodEqual 'ApplicationStateRemoved,ReadyForInno' ($receipt.WrittenPhases -join ',') 'partial deletion retry only repeats application deletion phases'
+        $fake2.World.LegacyCompatibilityVerified = $false
+        Assert-CcodThrows { Invoke-CcodLifecycleUninstallCleanupTest -InstallRoot $install -Transaction $transaction -Adapters $fake2.Adapters } 'CCOD_UNINSTALL_APPLICATION_STATE_REMOVAL_FAILED'
         Assert-CcodEqual 0 $fake2.World.TaskRemoved 'partial deletion retry never repeats task removal'
         Assert-CcodEqual 0 $fake2.World.AutomationPaused 'partial deletion retry does not touch deleted state files'
-        Assert-CcodTrue (-not (Test-Path -LiteralPath $install)) 'partial deletion retry removes the remaining application tree'
+        Assert-CcodEqual 1 $fake2.World.LegacyCompatibilityVerifyCalls 'partial deletion retry requires a fresh ordinary-state proof'
+        Assert-CcodTrue (Test-Path -LiteralPath $install) 'missing active-runtime evidence blocks further application deletion'
     } finally {
         foreach ($path in @($source, $install, $nodeRoot)) { if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Recurse -Force } }
     }
@@ -1834,19 +1968,19 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-setup\.exe\.sha256\.txt') 'build script writes a hash beside the public setup filename'
 }
 
-$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.5.4 release artifacts' {
+$results += Invoke-CcodTest 'installer publishes the exact CodexRemote-fix 2.5.5 release artifacts' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.4' ([string]$package.version) 'package version is exactly 2.5.4'
+    Assert-CcodEqual '2.5.5' ([string]$package.version) 'package version is exactly 2.5.5'
 
     $installerScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\CodexControlOtherDevices.iss') -Raw
     $outputBase = [regex]::Match($installerScript, '(?m)^OutputBaseFilename=(.+)$').Groups[1].Value.Trim()
     $setupName = ($outputBase -replace '\{#ProjectVersion\}', [string]$package.version) + '.exe'
-    Assert-CcodEqual 'CodexRemote-fix-2.5.4-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.5.5-setup.exe' $setupName 'Inno output resolves to the exact public setup filename'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     $checksumTemplate = [regex]::Match($buildScript, 'Join-Path \$dist \("([^"]+\.sha256\.txt)"\)').Groups[1].Value
     $checksumName = $checksumTemplate.Replace('$Version', [string]$package.version)
-    Assert-CcodEqual 'CodexRemote-fix-2.5.4-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
+    Assert-CcodEqual 'CodexRemote-fix-2.5.5-setup.exe.sha256.txt' $checksumName 'build script resolves to the exact public checksum filename'
 }
 
 # Production mutation caught: allowing raw activation JSON to authorize Ready/Failed, checking the deadline after terminal processing, prompting without a strict validator child exit, or synchronously waiting on an unbounded validator.
@@ -2198,16 +2332,16 @@ $results += Invoke-CcodTest 'README and release workflow publish current install
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe') 'English Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.5-setup\.exe') 'English Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.5-setup\.exe\.sha256\.txt') 'English Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStart -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'English Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStart -cmatch '\*\*CodexRemote-fix\*\*') 'English Quick Start names the public desktop shortcut'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.4-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.5-setup\.exe') 'Chinese Quick Start names the exact setup artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.5-setup\.exe\.sha256\.txt') 'Chinese Quick Start names the exact checksum artifact'
     Assert-CcodTrue ($quickStartChinese -cnotmatch '(?i)powershell|Install-CodexControlOtherDevices') 'Chinese Quick Start does not teach PowerShell installation'
     Assert-CcodTrue ($quickStartChinese -cmatch '\*\*CodexRemote-fix\*\*') 'Chinese Quick Start names the public desktop shortcut'
 

--- a/tests/persistence/ReleaseWorkflow.SelfTest.ps1
+++ b/tests/persistence/ReleaseWorkflow.SelfTest.ps1
@@ -188,20 +188,21 @@ Invoke-CcodTest 'package scripts build provenance and workflows retain the relea
     Assert-CcodTrue ($release -cmatch '(?ms)^  publish:\r?\n    needs: build\r?\n    runs-on: windows-latest\r?\n    permissions:\r?\n      contents: write\s*$') 'only the publish job receives release-write permission'
 }
 
-Invoke-CcodTest '2.5.4 current documentation matches the lifecycle tray and uninstall contract' {
+Invoke-CcodTest '2.5.5 current documentation matches the lifecycle tray and uninstall contract' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.4' ([string]$package.version) 'package metadata is the 2.5.4 release'
+    Assert-CcodEqual '2.5.5' ([string]$package.version) 'package metadata is the 2.5.5 release'
 
     $changelog = Get-Content -LiteralPath (Join-Path $repositoryRoot 'CHANGELOG.md') -Raw
-    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.4\s*\r?\n(?<body>.*?)(?=^## |\z)')
-    Assert-CcodTrue $releaseSection.Success 'v2.5.4 release section exists'
+    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.5\s*\r?\n(?<body>.*?)(?=^## |\z)')
+    Assert-CcodTrue $releaseSection.Success 'v2.5.5 release section exists'
     $releaseBody = $releaseSection.Groups['body'].Value
-    Assert-CcodTrue ($releaseBody -match '(?m)^### English\s*$') 'v2.5.4 release section is English'
-    Assert-CcodTrue ($releaseBody.Contains('Made fail-closed uninstall recovery preclaim a durable nonempty controller result placeholder so it works with a still-manifest-sealed older controller runtime.')) 'v2.5.4 legacy controller compatibility release bullet is exact'
-    Assert-CcodTrue ($releaseBody.Contains('Added regression coverage for the legacy strict byte-array writer and the prelaunch placeholder ordering.')) 'v2.5.4 regression release bullet is exact'
+    Assert-CcodTrue ($releaseBody -match '(?m)^### English\s*$') 'v2.5.5 release section is English'
+    Assert-CcodTrue ($releaseBody.Contains('Added a tightly scoped compatibility inspection for an older manifest-sealed controller that omitted its `ProcessControl` import. It accepts only the exact correlated legacy failure and requires a manifest-verified read-only ordinary-session recheck immediately before each protected uninstall deletion boundary.')) 'v2.5.5 legacy controller compatibility release bullet is exact'
+    Assert-CcodTrue ($releaseBody.Contains('New `SessionController` runtimes now load `ProcessControl` globally, and regression coverage rejects every other controller failure or changed compatibility proof.')) 'v2.5.5 regression release bullet is exact'
 
     $readme = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.md') -Raw
-    Assert-CcodTrue ($readme.Contains('CodexRemote-fix-2.5.4-setup.exe')) 'English Quick Start names the 2.5.4 installer'
+    $quickStart = [regex]::Match($readme, '(?ms)^## Quick start\s*\r?\n(?<body>.*?)(?=^## |\z)').Groups['body'].Value
+    Assert-CcodTrue ($quickStart.Contains('CodexRemote-fix-2.5.5-setup.exe')) 'English Quick Start names the 2.5.5 installer'
     Assert-CcodTrue ($readme.Contains('## Connection and protection status')) 'English README documents the current status contract'
     foreach ($state in @('Waiting for Codex', 'Checking', 'Connected', 'Repair needed', 'Error', 'Running', 'Reconnecting', 'Stopping')) {
         Assert-CcodTrue ($readme.Contains($state)) "English README documents state: $state"
@@ -215,7 +216,8 @@ Invoke-CcodTest '2.5.4 current documentation matches the lifecycle tray and unin
     Assert-CcodTrue (-not $readme.Contains('Automation, Candidate-compatible trial, Logs, and Uninstall')) 'English README no longer describes removed tray toggles'
 
     $readmeZh = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.zh-CN.md') -Raw -Encoding UTF8
-    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.4-setup.exe')) 'Chinese Quick Start names the 2.5.4 installer'
+    $quickStartZh = [regex]::Match($readmeZh, '(?ms)^## \u5FEB\u901F\u5F00\u59CB\s*\r?\n(?<body>.*?)(?=^## |\z)').Groups['body'].Value
+    Assert-CcodTrue ($quickStartZh.Contains('CodexRemote-fix-2.5.5-setup.exe')) 'Chinese Quick Start names the 2.5.5 installer'
     Assert-CcodTrue ($readmeZh -match '## \u8FDE\u63A5\u4E0E\u5B88\u62A4\u72B6\u6001') 'Chinese README documents the current status contract'
     foreach ($statePattern in @('\u7B49\u5F85 Codex', '\u6B63\u5728\u68C0\u67E5', '\u5DF2\u8FDE\u63A5', '\u9700\u8981\u4FEE\u590D', '\u9519\u8BEF', '\u8FD0\u884C\u4E2D', '\u6B63\u5728\u91CD\u8FDE', '\u6B63\u5728\u505C\u6B62')) {
         Assert-CcodTrue ($readmeZh -match $statePattern) "Chinese README documents state pattern: $statePattern"

--- a/tests/persistence/SessionController.SelfTest.ps1
+++ b/tests/persistence/SessionController.SelfTest.ps1
@@ -117,6 +117,14 @@ function Invoke-CcodLeasedTestController {
 $root=Join-Path ([IO.Path]::GetTempPath()) ('ccod-controller-selftest-'+[guid]::NewGuid().ToString('N'))
 try{
     $paths=New-CcodControllerPaths $root;$resultPath=Join-Path $root 'result.json'
+    Invoke-CcodTest 'controller exposes ProcessControl globally so legacy provenance parses the exact child command line' {
+        $processControl=Get-Module -Name ProcessControl -ErrorAction SilentlyContinue
+        Assert-CcodTrue ($null -ne $processControl) 'SessionController imports ProcessControl into the controller-visible module table'
+        $adapter=Get-CcodControllerAdapters $null
+        $commandLine='powershell.exe -NoProfile -File "C:\work\child.ps1" -RequestPath "C:\Temp\request.json"'
+        $tokens=@(& $adapter.ParseProcessCommandLine $commandLine)
+        Assert-CcodEqual 'powershell.exe,-NoProfile,-File,C:\work\child.ps1,-RequestPath,C:\Temp\request.json' ($tokens -join ',') 'legacy provenance receives the native parsed process command-line tokens instead of an empty array'
+    }
     Invoke-CcodTest 'schema-v2 controller dispatches only the fenced Inspect Close Apply and RepairRenderer allow-list' {
         foreach($action in @('Inspect','Close','Apply','RepairRenderer')){
             $events=[Collections.Generic.List[string]]::new();$request=New-CcodControllerV2Request -Action $action

--- a/tests/persistence/TrayHostBuild.SelfTest.ps1
+++ b/tests/persistence/TrayHostBuild.SelfTest.ps1
@@ -4,14 +4,14 @@ $ErrorActionPreference='Stop'
 $repositoryRoot=Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $lockPath=Join-Path $repositoryRoot 'build\trayhost-packages.lock.json'
 
-Invoke-CcodTest '2.5.4 source metadata binds the package and TrayHost assembly identities' {
+Invoke-CcodTest '2.5.5 source metadata binds the package and TrayHost assembly identities' {
     $package=Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw|ConvertFrom-Json
-    Assert-CcodEqual '2.5.4' ([string]$package.version) 'package version is the 2.5.4 release version'
+    Assert-CcodEqual '2.5.5' ([string]$package.version) 'package version is the 2.5.5 release version'
     $assemblyInfo=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\AssemblyInfo.cs') -Raw
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.4\.0"\)') 'TrayHost assembly version is 2.5.4.0'
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.4\.0"\)') 'TrayHost file version is 2.5.4.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.5\.0"\)') 'TrayHost assembly version is 2.5.5.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.5\.0"\)') 'TrayHost file version is 2.5.5.0'
     $manifest=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\CodexRemote.TrayHost.manifest') -Raw
-    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.4\.0"') 'TrayHost manifest identity is 2.5.4.0'
+    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.5\.0"') 'TrayHost manifest identity is 2.5.5.0'
 }
 
 Invoke-CcodTest 'TrayHost build lock pins the Microsoft net48 reference package' {
@@ -48,14 +48,14 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
     Import-Module $modulePath -Force
     $artifact=Join-Path $env:TEMP ('ccod-trayhost-artifact-'+[Guid]::NewGuid().ToString('N'))
     try{
-        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.4' -OutputDirectory $artifact
+        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.5' -OutputDirectory $artifact
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe') -PathType Leaf) 'TrayHost executable exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe.config') -PathType Leaf) 'TrayHost config exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -PathType Leaf) 'TrayHost provenance exists'
         $provenance=Get-Content -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -Raw|ConvertFrom-Json
-        Assert-CcodEqual '2.5.4' ([string]$provenance.version) 'provenance version is exact'
+        Assert-CcodEqual '2.5.5' ([string]$provenance.version) 'provenance version is exact'
         $fileVersion=[Diagnostics.FileVersionInfo]::GetVersionInfo((Join-Path $artifact 'CodexRemote.TrayHost.exe')).FileVersion
-        Assert-CcodEqual '2.5.4.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
+        Assert-CcodEqual '2.5.5.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
         Assert-CcodTrue ([string]$provenance.gitCommit -cmatch '^[0-9a-f]{40}$') 'provenance records one canonical source commit'
         $provenanceTimestamp=[datetime]::MinValue
         Assert-CcodTrue ([datetime]::TryParse([string]$provenance.buildTimestampUtc,[Globalization.CultureInfo]::InvariantCulture,[Globalization.DateTimeStyles]::RoundtripKind,[ref]$provenanceTimestamp)) 'provenance records a parseable build timestamp'
@@ -67,10 +67,10 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
         Assert-CcodTrue (@($provenance.sourceFiles).Count -ge 10) 'provenance includes every TrayHost source'
         Assert-CcodTrue (-not ([string]$provenance|Select-String -Pattern '[A-Za-z]:\\|\\\\' -Quiet)) 'provenance does not leak absolute paths'
         $currentCommit=(& git -C $repositoryRoot rev-parse HEAD).Trim().ToLowerInvariant()
-        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.4' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
+        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.5' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
         Assert-CcodEqual $currentCommit ([string]$validated.GitCommit) 'artifact validation binds the current source commit when requested'
         $tampered=Join-Path $artifact 'CodexRemote.TrayHost.exe.config'; Add-Content -LiteralPath $tampered -Value 'x'
-        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.4' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
+        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.5' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
         Assert-CcodTrue $threw 'tampered artifact is rejected'
     }finally{if(Test-Path -LiteralPath $artifact){Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue}}
 }

--- a/tests/trayhost/TrayHostNativeSelfTest.cs
+++ b/tests/trayhost/TrayHostNativeSelfTest.cs
@@ -57,9 +57,9 @@ internal static class TrayHostNativeSelfTest
     private static PresentationSnapshot SnapshotV2(ulong revision)
     {
         string[] strings = new string[] {
-            "CodexRemote-fix 2.5.4", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
+            "CodexRemote-fix 2.5.5", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
             "Language / 语言", "Follow system (English)", "中文", "English", "Open logs", "About", "Exit",
-            "About", "CodexRemote-fix | Version 2.5.4", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
+            "About", "CodexRemote-fix | Version 2.5.5", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
         };
         return new PresentationSnapshot(revision, TrayColor.Green, ConnectionState.Connected, ProtectionState.Running, LanguageMode.English,
             PresentationFlags.LanguageEnabled | PresentationFlags.OpenLogsEnabled | PresentationFlags.AboutEnabled | PresentationFlags.ExitEnabled, strings);
@@ -147,7 +147,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform();
         TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         platform.TrackResult = 0; window.HandleContextMenu(new TrayPoint(0, 0));
-        AssertEqual("CodexRemote-fix 2.5.4|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
+        AssertEqual("CodexRemote-fix 2.5.5|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
         AssertTrue(!platform.AppendedText.Contains("Allow compatible update trials"), "candidate toggle is removed");
         AssertTrue(!platform.Commands.Contains(1009U), "tray uninstall command is removed");
         TrayCommand selected = TrayCommand.None; window.CommandSelected += delegate(TrayCommand command, ulong revision) { selected = command; };
@@ -163,7 +163,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform(); TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         window.ShowAbout();
         AssertTrue(platform.MessageBoxes.Count == 1, "verified About shows exactly one native message box");
-        AssertEqual("About|CodexRemote-fix | Version 2.5.4", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
+        AssertEqual("About|CodexRemote-fix | Version 2.5.5", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
         window.Dispose();
     }
 


### PR DESCRIPTION
## Summary
- recognize only the correlated missing-ProcessControl legacy controller failure
- perform manifest-verified read-only ordinary-session checks before every protected uninstall deletion boundary
- load ProcessControl globally in new controller runtimes and release v2.5.5

## Validation
- npm test
- InstallLifecycle.SelfTest.ps1 (86 cases)
- SessionController.SelfTest.ps1 (31 cases)
- ReleaseWorkflow.SelfTest.ps1
- TrayHostBuild.SelfTest.ps1
- local v2.5.5 installer build
- live read-only compatibility inspection against the installed sealed v2.5.0 runtime