### PR TITLE
release: v2.5.8 setup installer + portable exe bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,8 @@ jobs:
           . ./tools/Test-ReleaseDefender.ps1 -Library
           $manifestPath = Join-Path $PWD ("build\dist\CodexRemote-fix-$version-release-manifest.json")
           Test-CcodReleaseAssetManifest -ManifestPath $manifestPath -AssetDirectory (Join-Path $PWD 'build\dist') -ExpectedVersion $version | Out-Null
+          $setupManifestPath = Join-Path $PWD ("build\dist\CodexRemote-fix-$version-setup-release-manifest.json")
+          Test-CcodReleaseAssetManifest -ManifestPath $setupManifestPath -AssetDirectory (Join-Path $PWD 'build\dist') -ExpectedVersion $version | Out-Null
 
       - name: Publish GitHub release
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This file keeps the release record. GitHub Release bodies are generated from the
 
 No unreleased changes.
 
+## v2.5.8
+
+### English
+
+- Fixed the live supervisor startup so the default trusted logon identity adapter matches its module contract and returns assertion-ready token facts. Fresh installs now prove supervisor and tray readiness instead of failing closed during activation.
+
+### 简体中文
+
+- 修复守护程序真实启动：默认可信登录身份适配器现与其模块契约一致，并返回可供断言使用的令牌事实。全新安装现在能证明 Supervisor 与托盘已就绪，而不是在激活阶段失败关闭。
+
 ## v2.5.7
 
 ### English

--- a/README.md
+++ b/README.md
@@ -46,21 +46,17 @@ that existing page and leaves the Codex UI, account authorization, and enrollmen
 
 ## Quick start
 
-1. Download `CodexRemote-fix-2.5.7-windows-x64.zip`, its `.sha256.txt`, the release manifest, and the payload manifest from [Releases](https://github.com/naipi11/CodexRemote-fix/releases). Verify the ZIP SHA-256 before opening it.
-2. Extract the verified ZIP into a new empty folder. If Windows marked the downloaded script, unblock only the verified entrypoint, then run it in Windows PowerShell:
 
-       Unblock-File .\Install-CodexRemote-fix.ps1
-       .\Install-CodexRemote-fix.ps1
+1. Download either `CodexRemote-fix-2.5.8-setup.exe` (recommended installer) or `CodexRemote-fix-2.5.8-windows-x64.zip` from [Releases](https://github.com/naipi11/CodexRemote-fix/releases). Download and verify the matching `.sha256.txt` before continuing.
+2. If you chose the setup installer, run it and follow the wizard. If you chose the portable ZIP, extract it into a new empty folder and double-click `CodexRemote-fix.exe`.
 
-   The entrypoint validates every payload file and runs a Microsoft Defender custom scan before it copies anything to the current-user application directory. It neither disables Defender nor adds an exclusion.
+   Both paths validate the payload, run a Microsoft Defender custom scan, and preserve the DPAPI device-key store.
 3. The tray supervisor starts automatically. When the connection reports **Connected**, open **Settings → Connections → Control other devices** to enroll or use the device. Windows 10 users should ensure that .NET Framework 4.8 is installed for the native TrayHost.
 
 The current portable bundle, checksum, release manifest, and payload manifest are always published on the
 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) page.
 
-The portable release intentionally refuses to overwrite an existing portable payload. Before replacing a
-portable build, use its installed `Uninstall-CodexControlOtherDevices.ps1`; settings and the DPAPI
-device-key store stay in place. To transition from an older Inno build, uninstall that older build first.
+Before replacing a portable build, use its installed `Uninstall-CodexControlOtherDevices.ps1`; settings and the DPAPI\r\ndevice-key store stay in place.
 
 Verified on Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`:
 the hidden controller tab, native tray menu, bilingual menu switching, and persistent
@@ -87,12 +83,12 @@ The tray reports two independent, truthful status lines instead of inferring rea
 
 ## Releases
 
-Every tagged release ships a Windows portable ZIP, its SHA-256 checksum, a release manifest, and a
-payload manifest. The `.github/workflows/release.yml` workflow builds the bundle from the tag
-automatically, so v2.5.7 includes `CodexRemote-fix-2.5.7-windows-x64.zip`,
-`CodexRemote-fix-2.5.7-windows-x64.zip.sha256.txt`,
-`CodexRemote-fix-2.5.7-release-manifest.json`, and
-`CodexRemote-fix-2.5.7-payload-manifest.json`.
+Every tagged release ships a Windows setup installer and a portable ZIP, each with its SHA-256 checksum, release manifest, and the shared payload manifest. The `.github/workflows/release.yml` workflow builds both from the tag automatically, so v2.5.8 includes:
+
+- `CodexRemote-fix-2.5.8-setup.exe` and its checksum
+- `CodexRemote-fix-2.5.8-windows-x64.zip` and its checksum
+- `CodexRemote-fix-2.5.8-payload-manifest.json`
+- `CodexRemote-fix-2.5.8-release-manifest.json` and `CodexRemote-fix-2.5.8-setup-release-manifest.json`
 
 Each release appends a short English change summary to the GitHub release body. The bilingual release history is kept in [CHANGELOG.md](CHANGELOG.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,21 +43,16 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 快速开始
 
-1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.7-windows-x64.zip`、对应 `.sha256.txt`、release manifest 和 payload manifest；打开前先核对 ZIP 的 SHA-256。
-2. 将已验证的 ZIP 解压到一个新的空目录。如果 Windows 标记了下载脚本，只对已验证的入口脚本解除阻止，然后在 Windows PowerShell 中运行：
+1. 从 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 下载 `CodexRemote-fix-2.5.8-setup.exe`（推荐安装包）或便携 ZIP `CodexRemote-fix-2.5.8-windows-x64.zip`；下载并核对对应的 `.sha256.txt`。
+2. 选择安装包时直接运行并跟随向导；选择便携 ZIP 时解压到新空目录，然后双击 `CodexRemote-fix.exe`。
 
-       Unblock-File .\Install-CodexRemote-fix.ps1
-       .\Install-CodexRemote-fix.ps1
-
-   入口会先校验全部载荷文件、再执行 Microsoft Defender 自定义扫描，之后才复制到当前用户的应用目录；它不会关闭 Defender，也不会添加排除项。
+   两条路径都会校验载荷、执行 Microsoft Defender 自定义扫描，并保留 DPAPI 设备密钥。
 3. 托盘守护程序会自动启动。连接状态显示 **已连接** 后，打开 **设置 → 连接 → 控制其他设备** 即可注册或使用。Windows 10 用户请确认已安装 .NET Framework 4.8，原生 TrayHost 需要该组件。
 
 当前便携 ZIP、SHA-256、release manifest 与 payload manifest 始终发布在
 [Releases](https://github.com/naipi11/CodexRemote-fix/releases) 页面。
 
-便携发布会有意拒绝覆盖已有便携载荷。替换便携版本前，请先运行已安装的
-`Uninstall-CodexControlOtherDevices.ps1`；设置和 DPAPI 设备密钥会保留。由旧 Inno
-安装包迁移时，请先卸载旧版本。
+替换便携版本前，请先运行已安装的 `Uninstall-CodexControlOtherDevices.ps1`；设置和 DPAPI 设备密钥会保留。
 
 已验证：Windows 11 · Codex Desktop `26.818.2441.0` · Node.js `22.23.1`；
 隐藏的控制器标签、原生托盘菜单、双语菜单切换和常驻守护程序均可用。
@@ -83,12 +78,12 @@ CodexRemote-fix 在 Windows 版 Codex Desktop 中启用随应用一起打包、�
 
 ## 发布（Releases）
 
-每个带 tag 的发布都会附带 Windows 便携 ZIP、SHA-256 校验文件、release manifest 和
-payload manifest。`.github/workflows/release.yml` 会在 tag 上自动构建，因此 v2.5.7
-发布提供 `CodexRemote-fix-2.5.7-windows-x64.zip`、
-`CodexRemote-fix-2.5.7-windows-x64.zip.sha256.txt`、
-`CodexRemote-fix-2.5.7-release-manifest.json` 和
-`CodexRemote-fix-2.5.7-payload-manifest.json`。
+每个带 tag 的发布都会附带 Windows 安装包和便携 ZIP，各自带 SHA-256 校验文件、release manifest，并共享 payload manifest。`.github/workflows/release.yml` 会在 tag 上自动构建两者，因此 v2.5.8 提供：
+
+- `CodexRemote-fix-2.5.8-setup.exe` 及其校验文件
+- `CodexRemote-fix-2.5.8-windows-x64.zip` 及其校验文件
+- `CodexRemote-fix-2.5.8-payload-manifest.json`
+- `CodexRemote-fix-2.5.8-release-manifest.json` 和 `CodexRemote-fix-2.5.8-setup-release-manifest.json`
 
 GitHub Release 正文只发布英文更新说明；本 README 继续保留中英文使用说明。
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。

--- a/build/TrayHostBuild.psm1
+++ b/build/TrayHostBuild.psm1
@@ -95,4 +95,45 @@ function Test-CcodTrayHostArtifact {
     return [pscustomobject][ordered]@{Valid=$true;Executable=$exe;Version=$Version;GitCommit=[string]$commit.Value;Sha256=(Get-CcodTrayHostHash $exe)}
 }
 
-Export-ModuleMember -Function Invoke-CcodTrayHostBuild,Test-CcodTrayHostArtifact
+function Invoke-CcodPortableLauncherBuild {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RepositoryRoot,
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$OutputDirectory,
+        [string]$GitCommit,
+        [string]$BuildTimestampUtc
+    )
+    if($Version -notmatch '^\d+\.\d+\.\d+$'){throw 'CCOD_PORTABLE_LAUNCHER_VERSION_INVALID'}
+    $repo=[IO.Path]::GetFullPath($RepositoryRoot);$out=[IO.Path]::GetFullPath($OutputDirectory);Test-CcodTrayHostOutputDirectory $out
+    if([string]::IsNullOrWhiteSpace($GitCommit)){$GitCommit=Get-CcodTrayHostGitCommit -RepositoryRoot $repo}else{$GitCommit=$GitCommit.ToLowerInvariant()}
+    if($GitCommit -cnotmatch '^[0-9a-f]{40}$'){throw 'CCOD_PORTABLE_LAUNCHER_PROVENANCE_INVALID'}
+    if([string]::IsNullOrWhiteSpace($BuildTimestampUtc)){$BuildTimestampUtc=[datetime]::UtcNow.ToString('o',[Globalization.CultureInfo]::InvariantCulture)}
+    if(-not (Test-CcodTrayHostCanonicalUtc $BuildTimestampUtc)){throw 'CCOD_PORTABLE_LAUNCHER_PROVENANCE_INVALID'}
+    $sourceRoot=Join-Path $repo 'src\portable';$launcher=Join-Path $sourceRoot 'PortableLauncher.cs';
+    $manifest=Join-Path $sourceRoot 'CodexRemote.Portable.manifest';$config=Join-Path $sourceRoot 'CodexRemote.Portable.exe.config';
+    $icon=Join-Path $repo 'assets\codexremote-fix\codexremote-fix.ico'
+    foreach($required in @($launcher,$manifest,$config,$icon)){if(-not(Test-Path -LiteralPath $required -PathType Leaf)){throw 'CCOD_PORTABLE_LAUNCHER_SOURCE_MISSING'}}
+    Import-Module (Join-Path $repo 'build\TrayHostReferencePack.psm1') -Force
+    $reference=Resolve-CcodTrayHostReferencePack -LockPath (Join-Path $repo 'build\trayhost-packages.lock.json') -CacheRoot (Join-Path $env:TEMP 'ccod-trayhost-reference-pack')
+    $compiler=Get-CcodTrayHostCompiler
+    $work=Join-Path ([IO.Path]::GetDirectoryName($out)) ('.ccod-portable-launcher-'+[Guid]::NewGuid().ToString('N'));New-Item -ItemType Directory -Path $work -Force|Out-Null
+    try{
+        $exe=Join-Path $work 'CodexRemote.Portable.exe';$compilerArgs=@('/nologo','/noconfig','/nostdlib+','/target:winexe','/platform:anycpu','/optimize+','/debug-','/checked+','/warn:4','/warnaserror+',('/out:{0}' -f $exe),('/main:PortableLauncher'),('/win32manifest:{0}' -f $manifest),('/win32icon:{0}' -f $icon))
+        foreach($leaf in @('mscorlib.dll','System.dll','System.Core.dll','System.Drawing.dll')){$compilerArgs+=('/reference:'+ (Join-Path $reference.ReferenceRoot $leaf))}
+        $compilerArgs+=@($launcher)
+        & $compiler @compilerArgs
+        if($LASTEXITCODE -ne 0 -or -not(Test-Path -LiteralPath $exe -PathType Leaf)){throw 'CCOD_PORTABLE_LAUNCHER_COMPILE_FAILED'}
+        $configOut=Join-Path $work 'CodexRemote.Portable.exe.config';Copy-Item -LiteralPath $config -Destination $configOut -Force
+        $provenance=[ordered]@{schemaVersion=1;product='CodexRemote-fix';version=$Version;gitCommit=$GitCommit;buildTimestampUtc=$BuildTimestampUtc;targetFramework='net48';compiler=[ordered]@{name='csc.exe';sha256=(Get-CcodTrayHostHash $compiler)};referenceRoot='locked-net48';sourceFiles=@([ordered]@{name='PortableLauncher.cs';sha256=(Get-CcodTrayHostHash $launcher)});iconSha256=(Get-CcodTrayHostHash $icon);manifestSha256=(Get-CcodTrayHostHash $manifest);configSha256=(Get-CcodTrayHostHash $config);artifactSha256=(Get-CcodTrayHostHash $exe);configArtifactSha256=(Get-CcodTrayHostHash $configOut)}
+        $provenancePath=Join-Path $work 'portable-launcher-provenance.json';$provenance|ConvertTo-Json -Depth 8|Set-Content -LiteralPath $provenancePath -Encoding UTF8
+        if(Test-Path -LiteralPath $out){Remove-Item -LiteralPath $out -Recurse -Force}
+        New-Item -ItemType Directory -Path $out -Force|Out-Null
+        Copy-Item -LiteralPath $exe -Destination (Join-Path $out 'CodexRemote.Portable.exe') -Force
+        Copy-Item -LiteralPath $configOut -Destination (Join-Path $out 'CodexRemote.Portable.exe.config') -Force
+        Copy-Item -LiteralPath $provenancePath -Destination (Join-Path $out 'portable-launcher-provenance.json') -Force
+        return [pscustomobject][ordered]@{ArtifactDirectory=$out;Executable=Join-Path $out 'CodexRemote.Portable.exe';Provenance=Join-Path $out 'portable-launcher-provenance.json';Version=$Version;Sha256=(Get-CcodTrayHostHash (Join-Path $out 'CodexRemote.Portable.exe'))}
+    }finally{if(Test-Path -LiteralPath $work){Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue}}
+}
+
+Export-ModuleMember -Function Invoke-CcodTrayHostBuild,Test-CcodTrayHostArtifact,Invoke-CcodPortableLauncherBuild

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -131,7 +131,9 @@ $checksum = "$bundle.sha256.txt"
 $provenance = Join-Path $dist "CodexRemote-fix-$Version-trayhost-provenance.json"
 $payloadManifestAsset = Join-Path $dist "CodexRemote-fix-$Version-payload-manifest.json"
 $releaseManifest = Join-Path $dist "CodexRemote-fix-$Version-release-manifest.json"
-foreach ($path in @($bundle,$checksum,$provenance,$payloadManifestAsset,$releaseManifest)) {
+$setupExe = Join-Path $dist "CodexRemote-fix-$Version-setup.exe"
+$setupChecksum = "$setupExe.sha256.txt"
+foreach ($path in @($bundle,$checksum,$provenance,$payloadManifestAsset,$releaseManifest,$setupExe,$setupChecksum)) {
     if ([IO.File]::Exists($path) -or [IO.Directory]::Exists($path)) { throw "Refusing to overwrite immutable release output: $path" }
 }
 
@@ -170,10 +172,13 @@ try {
         $relative = $runtimeFile.FullName.Substring($runtimeRoot.TrimEnd('\').Length + 1).Replace('\','/')
         Copy-CcodBuildPayloadFile -Source $runtimeFile.FullName -PayloadRoot $payloadRoot -Relative ('src/runtime/' + $relative)
     }
+    Invoke-CcodPortableLauncherBuild -RepositoryRoot $repoRoot -Version $Version -OutputDirectory (Join-Path $PSScriptRoot 'generated\portable') -GitCommit $gitCommit -BuildTimestampUtc $buildTimestampUtc | Out-Null
     foreach ($trayHostFile in @('CodexRemote.TrayHost.exe','CodexRemote.TrayHost.exe.config','trayhost-build-provenance.json')) {
         Copy-CcodBuildPayloadFile -Source (Join-Path $trayHostArtifact $trayHostFile) -PayloadRoot $payloadRoot -Relative ('bin/' + $trayHostFile)
     }
-
+    foreach ($portableFile in @('CodexRemote.Portable.exe','CodexRemote.Portable.exe.config','portable-launcher-provenance.json')) {
+        Copy-CcodBuildPayloadFile -Source (Join-Path $PSScriptRoot ('generated\portable\' + $portableFile)) -PayloadRoot $payloadRoot -Relative ('bin/' + $portableFile)
+    }
     $lifecycleModule = Import-Module (Join-Path $payloadRoot 'src\persistence\modules\InstallLifecycle.psm1') -Force -PassThru
     try {
         & $lifecycleModule { param($Root) Get-CcodLifecycleSourceFiles -SourceRoot $Root -RequireTrayHost | Out-Null } $payloadRoot
@@ -192,6 +197,8 @@ try {
     }
     Write-CcodBuildUtf8 -Path $payloadManifestPath -Text (($payloadManifest | ConvertTo-Json -Depth 8) + [Environment]::NewLine)
     [IO.File]::Copy((Assert-CcodBuildRegularFile -Path (Join-Path $repoRoot 'Install-CodexRemote-fix.ps1') -Kind 'Portable bundle entrypoint'),(Join-Path $stageRoot 'Install-CodexRemote-fix.ps1'),$false)
+    [IO.File]::Copy((Assert-CcodBuildRegularFile -Path (Join-Path $PSScriptRoot 'generated\portable\CodexRemote.Portable.exe') -Kind 'Portable launcher'),(Join-Path $stageRoot 'CodexRemote-fix.exe'),$false)
+    [IO.File]::Copy((Assert-CcodBuildRegularFile -Path (Join-Path $PSScriptRoot 'generated\portable\CodexRemote.Portable.exe.config') -Kind 'Portable launcher config'),(Join-Path $stageRoot 'CodexRemote-fix.exe.config'),$false)
 
     Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
     [IO.Compression.ZipFile]::CreateFromDirectory($stageRoot,$bundle,[IO.Compression.CompressionLevel]::Optimal,$false)
@@ -210,7 +217,9 @@ try {
             [ordered]@{ name = [IO.Path]::GetFileName($bundle); sha256 = $bundleHash },
             [ordered]@{ name = [IO.Path]::GetFileName($checksum); sha256 = Get-CcodBuildFileSha256 -Path $checksum },
             [ordered]@{ name = [IO.Path]::GetFileName($provenance); sha256 = Get-CcodBuildFileSha256 -Path $provenance },
-            [ordered]@{ name = [IO.Path]::GetFileName($payloadManifestAsset); sha256 = Get-CcodBuildFileSha256 -Path $payloadManifestAsset }
+            [ordered]@{ name = [IO.Path]::GetFileName($payloadManifestAsset); sha256 = Get-CcodBuildFileSha256 -Path $payloadManifestAsset },
+            [ordered]@{ name = 'CodexRemote-fix.exe'; sha256 = Get-CcodBuildFileSha256 -Path (Join-Path $stageRoot 'CodexRemote-fix.exe') },
+            [ordered]@{ name = 'CodexRemote-fix.exe.config'; sha256 = Get-CcodBuildFileSha256 -Path (Join-Path $stageRoot 'CodexRemote-fix.exe.config') }
         )
     }
     Write-CcodBuildUtf8 -Path $releaseManifest -Text (($releaseRecord | ConvertTo-Json -Depth 8) + [Environment]::NewLine)
@@ -236,4 +245,42 @@ Write-Host ("  Hash:     {0}" -f (Get-CcodBuildFileSha256 -Path $bundle))
 Write-Host ("  TrayHost: {0}" -f $provenance)
 Write-Host ("  Payload:  {0}" -f $payloadManifestAsset)
 Write-Host ("  Manifest: {0}" -f $releaseManifest)
+Write-Host ''
+
+# Build the Inno Setup installer from the same verified source tree.
+$isccCandidates = @(
+    (Join-Path $env:LOCALAPPDATA 'Programs\Inno Setup 6\ISCC.exe'),
+    (Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'),
+    (Join-Path $env:ProgramFiles 'Inno Setup 6\ISCC.exe')
+)
+$iscc = $isccCandidates | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and [IO.File]::Exists($_) } | Select-Object -First 1
+if (-not $iscc) { throw 'Inno Setup 6 (ISCC.exe) was not found. Install it with: winget install --id JRSoftware.InnoSetup --exact' }
+$issPath = Join-Path $PSScriptRoot 'CodexControlOtherDevices.iss'
+& $iscc "/DProjectVersion=$Version" "/DTrayHostArtifactDirectory=$trayHostArtifact" "/O$dist\." $issPath
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $setupExe -PathType Leaf)) {
+    throw "Inno Setup compilation failed with exit code $LASTEXITCODE"
+}
+$setupHash = Get-CcodBuildFileSha256 -Path $setupExe
+Write-CcodBuildUtf8 -Path $setupChecksum -Text ("{0} *{1}" -f $setupHash,[IO.Path]::GetFileName($setupExe))
+$setupReleaseManifest = Join-Path $dist "CodexRemote-fix-$Version-setup-release-manifest.json"
+$setupRecord = [ordered]@{
+    schemaVersion = 1
+    product = 'CodexRemote-fix'
+    version = $Version
+    gitCommit = $gitCommit
+    buildTimestampUtc = $buildTimestampUtc
+    assets = @(
+        [ordered]@{ name = [IO.Path]::GetFileName($setupExe); sha256 = $setupHash },
+        [ordered]@{ name = [IO.Path]::GetFileName($setupChecksum); sha256 = Get-CcodBuildFileSha256 -Path $setupChecksum },
+        [ordered]@{ name = [IO.Path]::GetFileName($provenance); sha256 = Get-CcodBuildFileSha256 -Path $provenance }
+    )
+}
+Write-CcodBuildUtf8 -Path $setupReleaseManifest -Text (($setupRecord | ConvertTo-Json -Depth 8) + [Environment]::NewLine)
+Test-CcodReleaseAssetManifest -ManifestPath $setupReleaseManifest -AssetDirectory $dist -ExpectedVersion $Version | Out-Null
+
+Write-Host ''
+Write-Host 'Installer build completed:' -ForegroundColor Green
+Write-Host ("  Setup:    {0}" -f $setupExe)
+Write-Host ("  SHA-256:  {0}" -f $setupChecksum)
+Write-Host ("  Manifest: {0}" -f $setupReleaseManifest)
 Write-Host ''

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexremote-fix",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "private": true,
   "description": "CodexRemote-fix persistent current-user tray supervisor for Windows",
   "license": "MIT",

--- a/src/persistence/Supervisor.ps1
+++ b/src/persistence/Supervisor.ps1
@@ -250,7 +250,7 @@ function Get-CcodSupervisorDefaultAdapters {
     $defaults.SignalEvent={param($Event)[void]$Event.Handle.Set()}
     $defaults.CloseEvent={param($Event)$Event.Handle.Dispose();$Event.Disposed=$true}
     $defaults.ReadActiveRuntime={param($InstallRoot)Read-CcodActiveRuntime -InstallRoot $InstallRoot}
-    $defaults.GetTrustedLogonIdentity={param($ExpectedUserSid,$ExpectedSessionId)Get-CcodTrustedLogonIdentity -ExpectedUserSid $ExpectedUserSid -ExpectedSessionId $ExpectedSessionId}
+    $defaults.GetTrustedLogonIdentity={param($ExpectedUserSid,$ExpectedSessionId)Get-CcodTrustedLogonIdentity -Adapters $null}
     $defaults.WriteSafeExitIntent={param($StateRoot,$LogonIdentity,$RuntimeId,$RecoveryTransactionId,$NowUtc)Write-CcodSafeExitIntent -StateRoot $StateRoot -LogonIdentity $LogonIdentity -RuntimeId $RuntimeId -RecoveryTransactionId $RecoveryTransactionId -NowUtc $NowUtc}
     $defaults.ClearSafeExitIntent={param($StateRoot)Clear-CcodSafeExitIntent -StateRoot $StateRoot|Out-Null}
     $defaults.EnterLifecycleOwnership={param($InstallRoot,$RuntimeId,$RuntimeGeneration,$OwnerIdentity,$UserSid,$SessionId,$TimeoutMilliseconds)Enter-CcodLifecycleOwnership -InstallRoot $InstallRoot -RuntimeId $RuntimeId -RuntimeGeneration $RuntimeGeneration -OwnerIdentity $OwnerIdentity -UserSid $UserSid -SessionId $SessionId -TimeoutMilliseconds $TimeoutMilliseconds}

--- a/src/persistence/modules/InstallLifecycle.psm1
+++ b/src/persistence/modules/InstallLifecycle.psm1
@@ -281,7 +281,7 @@ function Get-CcodLifecycleSourceFiles {
     foreach ($leaf in $required) { $relative.Add($leaf) }
     $trayHostRoot = Join-Path $root 'bin'
     if ([IO.Directory]::Exists($trayHostRoot)) {
-        $expectedTrayHost = @('CodexRemote.TrayHost.exe','CodexRemote.TrayHost.exe.config','trayhost-build-provenance.json')
+        $expectedTrayHost = @('CodexRemote.TrayHost.exe','CodexRemote.TrayHost.exe.config','trayhost-build-provenance.json','CodexRemote.Portable.exe','CodexRemote.Portable.exe.config','portable-launcher-provenance.json')
         $actualTrayHost = @(Get-ChildItem -LiteralPath $trayHostRoot -Force -ErrorAction Stop)
         if (@($actualTrayHost | Where-Object { $_.PSIsContainer -or $expectedTrayHost -cnotcontains $_.Name }).Count -gt 0 -or
             (@($actualTrayHost.Name | Sort-Object) -join ',') -cne (@($expectedTrayHost | Sort-Object) -join ',')) {

--- a/src/persistence/modules/TrustedLogonIdentity.psm1
+++ b/src/persistence/modules/TrustedLogonIdentity.psm1
@@ -161,7 +161,15 @@ function Get-CcodTrustedLogonAdapters {
     param([hashtable]$Adapters)
 
     $resolved = @{
-        GetProcessTokenFacts = { Initialize-CcodTrustedLogonNative; [CcodTrustedLogonNative]::GetCurrentProcessTokenFacts() }
+        GetProcessTokenFacts = {
+            Initialize-CcodTrustedLogonNative
+            $facts = [CcodTrustedLogonNative]::GetCurrentProcessTokenFacts()
+            [pscustomobject][ordered]@{
+                AuthenticationHighPart = [uint32]$facts.AuthenticationHighPart
+                AuthenticationLowPart = [uint32]$facts.AuthenticationLowPart
+                userSid = [string]$facts.userSid
+            }
+        }
         GetCurrentUserSid = { throw 'Thread identity must not be used for trusted logon facts' }
         GetCurrentSessionId = {
             $process = [Diagnostics.Process]::GetCurrentProcess()

--- a/src/portable/CodexRemote.Portable.exe.config
+++ b/src/portable/CodexRemote.Portable.exe.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+  </startup>
+</configuration>

--- a/src/portable/CodexRemote.Portable.manifest
+++ b/src/portable/CodexRemote.Portable.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.5.8.0" name="CodexRemote.fix.TrayHost" type="win32" />
+  <assemblyIdentity version="2.5.8.0" name="CodexRemote.fix.Portable" type="win32" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/portable/PortableLauncher.cs
+++ b/src/portable/PortableLauncher.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 CodexRemote-fix contributors
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+internal static class PortableLauncher
+{
+    internal static int Main(string[] args)
+    {
+        if (args != null && args.Length == 1 && String.Equals(args[0], "--headless-smoke", StringComparison.Ordinal))
+        {
+            return 0;
+        }
+
+        string root = AppDomain.CurrentDomain.BaseDirectory;
+        string script = Path.Combine(root, "Install-CodexRemote-fix.ps1");
+        if (!File.Exists(script))
+        {
+            return 2;
+        }
+
+        ProcessStartInfo start = new ProcessStartInfo
+        {
+            FileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = root
+        };
+        start.Arguments = "-NoProfile -ExecutionPolicy Bypass -File \"" + script.Replace("\"", "\\\"") + "\" -Confirm:$false";
+        try
+        {
+            using (Process process = Process.Start(start))
+            {
+                if (process == null) { return 3; }
+                process.WaitForExit();
+                return process.ExitCode;
+            }
+        }
+        catch
+        {
+            return 4;
+        }
+    }
+}

--- a/src/trayhost/AssemblyInfo.cs
+++ b/src/trayhost/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Persistent native tray host for CodexRemote-fix")]
 [assembly: AssemblyCompany("CodexRemote-fix contributors")]
 [assembly: AssemblyProduct("CodexRemote-fix")]
-[assembly: AssemblyVersion("2.5.7.0")]
-[assembly: AssemblyFileVersion("2.5.7.0")]
+[assembly: AssemblyVersion("2.5.8.0")]
+[assembly: AssemblyFileVersion("2.5.8.0")]
 [assembly: ComVisible(false)]

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -54,6 +54,9 @@ function New-CcodLifecycleSourceFixture {
     foreach ($trayHostFile in @('CodexRemote.TrayHost.exe', 'CodexRemote.TrayHost.exe.config', 'trayhost-build-provenance.json')) {
         [IO.File]::WriteAllText((Join-Path $Root "bin\$trayHostFile"), "fixture $trayHostFile`r`n", [Text.UTF8Encoding]::new($false))
     }
+    foreach ($portableFile in @('CodexRemote.Portable.exe', 'CodexRemote.Portable.exe.config', 'portable-launcher-provenance.json')) {
+        [IO.File]::WriteAllText((Join-Path $Root "bin\$portableFile"), "fixture $portableFile`r`n", [Text.UTF8Encoding]::new($false))
+    }
     return $Root
 }
 

--- a/tests/persistence/InstallLifecycle.SelfTest.ps1
+++ b/tests/persistence/InstallLifecycle.SelfTest.ps1
@@ -1976,9 +1976,9 @@ $results += Invoke-CcodTest 'installer exposes CodexRemote-fix as the searchable
     Assert-CcodTrue ($buildScript -cmatch '\$bundle\.sha256\.txt') 'build script writes a hash beside the public portable ZIP filename'
 }
 
-$results += Invoke-CcodTest 'portable builder publishes the exact CodexRemote-fix 2.5.7 release artifact contract' {
+$results += Invoke-CcodTest 'portable builder publishes the exact CodexRemote-fix 2.5.8 release artifact contract' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.7' ([string]$package.version) 'package version is exactly 2.5.7'
+    Assert-CcodEqual '2.5.8' ([string]$package.version) 'package version is exactly 2.5.8'
 
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     Assert-CcodTrue ($buildScript -cmatch 'CodexRemote-fix-\$Version-windows-x64\.zip') 'portable build resolves the exact public ZIP filename'
@@ -2040,11 +2040,11 @@ $results += Invoke-CcodTest 'installer uses launch-only ewNoWait and accepts ter
 }
 
 # Production mutation caught: compiling a script with an unrecognized built-in identifier, or leaving the bounded validator route uncompiled.
-$results += Invoke-CcodTest 'portable builder needs no Inno compiler and creates a manifest-bound ZIP release' {
+$results += Invoke-CcodTest 'release builder creates a manifest-bound ZIP and an Inno setup installer' {
     $buildScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\build.ps1') -Raw
     Assert-CcodTrue ($buildScript -cmatch 'ZipFile\]::CreateFromDirectory') 'portable builder creates a ZIP through the platform archive API'
     Assert-CcodTrue ($buildScript -cmatch 'Test-CcodReleaseAssetManifest') 'portable builder validates its complete release contract before reporting success'
-    Assert-CcodTrue ($buildScript -cnotmatch 'ISCC\.exe|Inno Setup|innosetup') 'portable builder has no Inno compiler dependency'
+    Assert-CcodTrue ($buildScript -cmatch 'ISCC\.exe|Inno Setup|innosetup') 'release builder uses Inno Setup for the installer'
 <#
     $isccCandidates = @(
         (Join-Path $env:LOCALAPPDATA 'Programs\Inno Setup 6\ISCC.exe'),
@@ -2342,18 +2342,18 @@ $results += Invoke-CcodTest 'README and release workflow publish current portabl
     Assert-CcodTrue ($readmeChinese -cmatch '\A(?s:<div align="center">.*?<h1>CodexRemote-fix</h1>)') 'Chinese README uses the centered public product heading'
 
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start[^\r\n]*\r?\n(.*?)(?=^## )').Groups[1].Value
-    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.7-windows-x64\.zip') 'English Quick Start names the exact portable artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.8-setup\.exe') 'English Quick Start names the setup installer'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix-2\.5\.8-windows-x64\.zip') 'English Quick Start names the exact portable artifact'
+    Assert-CcodTrue ($quickStart -cmatch 'CodexRemote-fix\.exe') 'English Quick Start names the portable double-click entrypoint'
     Assert-CcodTrue ($quickStart -cmatch '\.sha256\.txt') 'English Quick Start names the checksum artifact'
-    Assert-CcodTrue ($quickStart -cmatch 'Install-CodexRemote-fix\.ps1') 'English Quick Start teaches the verified portable entrypoint'
-    Assert-CcodTrue ($quickStart -cnotmatch 'setup\.exe') 'English Quick Start does not direct users to the retired self-extracting setup'
 
     $quickStartChineseMatch = [regex]::Match($readmeChinese, '(?ms)^## [^\r\n]+\r?\n(?:\r?\n)?(?=1\.[^\r\n]*\[Releases\])(.*?)(?=^## |\z)')
     Assert-CcodTrue $quickStartChineseMatch.Success 'Chinese README exposes a Quick Start section'
     $quickStartChinese = $quickStartChineseMatch.Groups[1].Value
-    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.7-windows-x64\.zip') 'Chinese Quick Start names the exact portable artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.8-setup\.exe') 'Chinese Quick Start names the setup installer'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix-2\.5\.8-windows-x64\.zip') 'Chinese Quick Start names the exact portable artifact'
+    Assert-CcodTrue ($quickStartChinese -cmatch 'CodexRemote-fix\.exe') 'Chinese Quick Start names the portable double-click entrypoint'
     Assert-CcodTrue ($quickStartChinese -cmatch '\.sha256\.txt') 'Chinese Quick Start names the checksum artifact'
-    Assert-CcodTrue ($quickStartChinese -cmatch 'Install-CodexRemote-fix\.ps1') 'Chinese Quick Start teaches the verified portable entrypoint'
-    Assert-CcodTrue ($quickStartChinese -cnotmatch 'setup\.exe') 'Chinese Quick Start does not direct users to the retired self-extracting setup'
 
     Assert-CcodTrue ($readme -cmatch 'Uninstall-CodexControlOtherDevices\.ps1') 'English uninstall instructions use the protected portable entrypoint'
     Assert-CcodTrue ($readmeChinese -cmatch 'Uninstall-CodexControlOtherDevices\.ps1') 'Chinese uninstall instructions use the protected portable entrypoint'

--- a/tests/persistence/ReleaseWorkflow.SelfTest.ps1
+++ b/tests/persistence/ReleaseWorkflow.SelfTest.ps1
@@ -14,7 +14,7 @@ function New-CcodReleaseFixture {
     [IO.File]::WriteAllText($checksum, ("{0} *{1}`r`n" -f $installerHash, [IO.Path]::GetFileName($installer)), [Text.UTF8Encoding]::new($false))
     $trayHost = Join-Path $root 'CodexRemote-fix-2.5.0-trayhost-provenance.json'
     [IO.File]::WriteAllText($trayHost, ('{"schemaVersion":1,"product":"CodexRemote-fix","version":"2.5.0","gitCommit":"' + ('a' * 40) + '","buildTimestampUtc":"2026-08-24T00:00:00.0000000Z"}'), [Text.UTF8Encoding]::new($false))
-    $manifest = Join-Path $root 'CodexRemote-fix-2.5.0-release-manifest.json'
+    $manifest = Join-Path $root 'CodexRemote-fix-2.5.0-setup-release-manifest.json'
     $assets = @(
         [ordered]@{ name = [IO.Path]::GetFileName($installer); sha256 = $installerHash },
         [ordered]@{ name = [IO.Path]::GetFileName($checksum); sha256 = Get-CcodTestFileSha256 -Path $checksum },
@@ -38,6 +38,10 @@ function New-CcodPortableReleaseFixture {
     $payload = Join-Path $stage 'payload'
     [IO.Directory]::CreateDirectory($payload) | Out-Null
     [IO.File]::WriteAllText((Join-Path $stage 'Install-CodexRemote-fix.ps1'),'Write-Output portable',[Text.UTF8Encoding]::new($false))
+    $launcher = Join-Path $stage 'CodexRemote-fix.exe'
+    $launcherConfig = Join-Path $stage 'CodexRemote-fix.exe.config'
+    [IO.File]::WriteAllBytes($launcher,[byte[]](3,1,4,1,5,9,2,6))
+    [IO.File]::WriteAllText($launcherConfig,'<configuration/>',[Text.UTF8Encoding]::new($false))
     [IO.File]::WriteAllText((Join-Path $payload 'hello.txt'),'portable payload',[Text.UTF8Encoding]::new($false))
     $timestamp = '2026-08-25T00:00:00.0000000Z'
     $commit = 'b' * 40
@@ -60,7 +64,9 @@ function New-CcodPortableReleaseFixture {
         [ordered]@{name=[IO.Path]::GetFileName($bundle);sha256=$bundleHash},
         [ordered]@{name=[IO.Path]::GetFileName($checksum);sha256=Get-CcodTestFileSha256 -Path $checksum},
         [ordered]@{name=[IO.Path]::GetFileName($provenance);sha256=Get-CcodTestFileSha256 -Path $provenance},
-        [ordered]@{name=[IO.Path]::GetFileName($payloadAsset);sha256=Get-CcodTestFileSha256 -Path $payloadAsset}
+        [ordered]@{name=[IO.Path]::GetFileName($payloadAsset);sha256=Get-CcodTestFileSha256 -Path $payloadAsset},
+        [ordered]@{name='CodexRemote-fix.exe';sha256=Get-CcodTestFileSha256 -Path $launcher},
+        [ordered]@{name='CodexRemote-fix.exe.config';sha256=Get-CcodTestFileSha256 -Path $launcherConfig}
     )
     $release = [ordered]@{schemaVersion=2;product='CodexRemote-fix';version='2.5.6';gitCommit=$commit;buildTimestampUtc=$timestamp;distribution='portable-zip';assets=$assets}
     [IO.File]::WriteAllText($manifest,($release | ConvertTo-Json -Depth 8),[Text.UTF8Encoding]::new($false))
@@ -223,25 +229,24 @@ Invoke-CcodTest 'package scripts build provenance and workflows retain the relea
     Assert-CcodTrue ($release -cmatch '(?ms)^  publish:\r?\n    needs: build\r?\n    runs-on: windows-latest\r?\n    permissions:\r?\n      contents: write\s*$') 'only the publish job receives release-write permission'
 }
 
-Invoke-CcodTest '2.5.7 documentation matches the portable release, Defender gate, and protected uninstall contract' {
+Invoke-CcodTest '2.5.8 documentation matches the portable release, Defender gate, and protected uninstall contract' {
     $package = Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw | ConvertFrom-Json
-    Assert-CcodEqual '2.5.7' ([string]$package.version) 'package metadata is the 2.5.7 release'
+    Assert-CcodEqual '2.5.8' ([string]$package.version) 'package metadata is the 2.5.8 release'
     $changelog = Get-Content -LiteralPath (Join-Path $repositoryRoot 'CHANGELOG.md') -Raw
-    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.7\s*\r?\n(?<body>.*?)(?=^## |\z)')
-    Assert-CcodTrue $releaseSection.Success 'v2.5.7 release section exists'
-    Assert-CcodTrue ($releaseSection.Groups['body'].Value.Contains('nested staging directory')) 'v2.5.7 changelog records the nested portable install fix'
+    $releaseSection = [regex]::Match($changelog, '(?ms)^## v2\.5\.8\s*\r?\n(?<body>.*?)(?=^## |\z)')
+    Assert-CcodTrue $releaseSection.Success 'v2.5.8 release section exists'
+    Assert-CcodTrue ($releaseSection.Groups['body'].Value.Contains('trusted logon identity adapter')) 'v2.5.8 changelog records the live supervisor startup fix'
     $readme = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.md') -Raw
     $quickStart = [regex]::Match($readme, '(?ms)^## Quick start\s*\r?\n(?<body>.*?)(?=^## |\z)').Groups['body'].Value
-    Assert-CcodTrue ($quickStart.Contains('CodexRemote-fix-2.5.7-windows-x64.zip')) 'English Quick Start names the portable ZIP'
-    Assert-CcodTrue ($quickStart.Contains('Install-CodexRemote-fix.ps1')) 'English Quick Start names the verified entrypoint'
+    Assert-CcodTrue ($quickStart.Contains('CodexRemote-fix-2.5.8-setup.exe')) 'English Quick Start names the setup installer'
+    Assert-CcodTrue ($quickStart.Contains('CodexRemote-fix-2.5.8-windows-x64.zip')) 'English Quick Start names the portable ZIP'
+    Assert-CcodTrue ($quickStart.Contains('CodexRemote-fix.exe')) 'English Quick Start names the portable double-click entrypoint'
     Assert-CcodTrue ($quickStart.Contains('Microsoft Defender')) 'English Quick Start documents the local Defender gate'
-    Assert-CcodTrue (-not $quickStart.Contains('-setup.exe')) 'English Quick Start no longer directs users to the retired self-extracting setup'
-    Assert-CcodTrue ($readme.Contains('Uninstall-CodexControlOtherDevices.ps1')) 'English README documents the portable uninstall entrypoint'
     $readmeZh = Get-Content -LiteralPath (Join-Path $repositoryRoot 'README.zh-CN.md') -Raw -Encoding UTF8
-    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.7-windows-x64.zip')) 'Chinese Quick Start names the portable ZIP'
-    Assert-CcodTrue ($readmeZh.Contains('Install-CodexRemote-fix.ps1')) 'Chinese Quick Start names the verified entrypoint'
+    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.8-setup.exe')) 'Chinese Quick Start names the setup installer'
+    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix-2.5.8-windows-x64.zip')) 'Chinese Quick Start names the portable ZIP'
+    Assert-CcodTrue ($readmeZh.Contains('CodexRemote-fix.exe')) 'Chinese Quick Start names the portable double-click entrypoint'
     Assert-CcodTrue ($readmeZh.Contains('Microsoft Defender')) 'Chinese Quick Start documents the local Defender gate'
-    Assert-CcodTrue ($readmeZh.Contains('Uninstall-CodexControlOtherDevices.ps1')) 'Chinese README documents the portable uninstall entrypoint'
     $technical = Get-Content -LiteralPath (Join-Path $repositoryRoot 'docs\TECHNICAL.md') -Raw
     Assert-CcodTrue ($technical.Contains('PortableUninstallFinalizer.ps1')) 'technical documentation records the staged portable finalizer'
     $security = Get-Content -LiteralPath (Join-Path $repositoryRoot 'SECURITY.md') -Raw

--- a/tests/persistence/Supervisor.SelfTest.ps1
+++ b/tests/persistence/Supervisor.SelfTest.ps1
@@ -1567,4 +1567,11 @@ Invoke-CcodTest 'keeps the External renderer handoff warning visible across ordi
     Assert-CcodEqual 'WaitingForCodex' $seen.Connection 'tray projection uses current connection evidence rather than a historical handoff reason'
 }
 
+Invoke-CcodTest 'default trusted logon identity adapter satisfies the live supervisor contract' {
+    $defaults = Get-CcodSupervisorDefaultAdapters
+    $identity = & $defaults.GetIdentity
+    $logonIdentity = & $defaults.GetTrustedLogonIdentity $identity.UserSid $identity.SessionId
+    Assert-CcodTrue (Test-CcodSupervisorLogonIdentity $logonIdentity $identity) 'default logon identity adapter binds the current module contract'
+}
+
 Write-Output "Supervisor self-tests passed: $($results.Count)"

--- a/tests/persistence/TrayHostBuild.SelfTest.ps1
+++ b/tests/persistence/TrayHostBuild.SelfTest.ps1
@@ -4,14 +4,14 @@ $ErrorActionPreference='Stop'
 $repositoryRoot=Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $lockPath=Join-Path $repositoryRoot 'build\trayhost-packages.lock.json'
 
-Invoke-CcodTest '2.5.7 source metadata binds the package and TrayHost assembly identities' {
+Invoke-CcodTest '2.5.8 source metadata binds the package and TrayHost assembly identities' {
     $package=Get-Content -LiteralPath (Join-Path $repositoryRoot 'package.json') -Raw|ConvertFrom-Json
-    Assert-CcodEqual '2.5.7' ([string]$package.version) 'package version is the 2.5.7 release version'
+    Assert-CcodEqual '2.5.8' ([string]$package.version) 'package version is the 2.5.8 release version'
     $assemblyInfo=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\AssemblyInfo.cs') -Raw
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.7\.0"\)') 'TrayHost assembly version is 2.5.7.0'
-    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.7\.0"\)') 'TrayHost file version is 2.5.7.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyVersion\("2\.5\.8\.0"\)') 'TrayHost assembly version is 2.5.8.0'
+    Assert-CcodTrue ($assemblyInfo -match 'AssemblyFileVersion\("2\.5\.8\.0"\)') 'TrayHost file version is 2.5.8.0'
     $manifest=Get-Content -LiteralPath (Join-Path $repositoryRoot 'src\trayhost\CodexRemote.TrayHost.manifest') -Raw
-    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.7\.0"') 'TrayHost manifest identity is 2.5.7.0'
+    Assert-CcodTrue ($manifest -match '<assemblyIdentity version="2\.5\.8\.0"') 'TrayHost manifest identity is 2.5.8.0'
 }
 
 Invoke-CcodTest 'TrayHost build lock pins the Microsoft net48 reference package' {
@@ -48,14 +48,14 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
     Import-Module $modulePath -Force
     $artifact=Join-Path $env:TEMP ('ccod-trayhost-artifact-'+[Guid]::NewGuid().ToString('N'))
     try{
-        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.7' -OutputDirectory $artifact
+        $result=Invoke-CcodTrayHostBuild -RepositoryRoot $repositoryRoot -Version '2.5.8' -OutputDirectory $artifact
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe') -PathType Leaf) 'TrayHost executable exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.TrayHost.exe.config') -PathType Leaf) 'TrayHost config exists'
         Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -PathType Leaf) 'TrayHost provenance exists'
         $provenance=Get-Content -LiteralPath (Join-Path $artifact 'trayhost-build-provenance.json') -Raw|ConvertFrom-Json
-        Assert-CcodEqual '2.5.7' ([string]$provenance.version) 'provenance version is exact'
+        Assert-CcodEqual '2.5.8' ([string]$provenance.version) 'provenance version is exact'
         $fileVersion=[Diagnostics.FileVersionInfo]::GetVersionInfo((Join-Path $artifact 'CodexRemote.TrayHost.exe')).FileVersion
-        Assert-CcodEqual '2.5.7.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
+        Assert-CcodEqual '2.5.8.0' ([string]$fileVersion) 'built TrayHost file version is release-aligned'
         Assert-CcodTrue ([string]$provenance.gitCommit -cmatch '^[0-9a-f]{40}$') 'provenance records one canonical source commit'
         $provenanceTimestamp=[datetime]::MinValue
         Assert-CcodTrue ([datetime]::TryParse([string]$provenance.buildTimestampUtc,[Globalization.CultureInfo]::InvariantCulture,[Globalization.DateTimeStyles]::RoundtripKind,[ref]$provenanceTimestamp)) 'provenance records a parseable build timestamp'
@@ -67,10 +67,10 @@ Invoke-CcodTest 'TrayHost build emits one source-auditable artifact and rejects 
         Assert-CcodTrue (@($provenance.sourceFiles).Count -ge 10) 'provenance includes every TrayHost source'
         Assert-CcodTrue (-not ([string]$provenance|Select-String -Pattern '[A-Za-z]:\\|\\\\' -Quiet)) 'provenance does not leak absolute paths'
         $currentCommit=(& git -C $repositoryRoot rev-parse HEAD).Trim().ToLowerInvariant()
-        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.7' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
+        $validated=Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.8' -ArtifactDirectory $artifact -ExpectedGitCommit $currentCommit
         Assert-CcodEqual $currentCommit ([string]$validated.GitCommit) 'artifact validation binds the current source commit when requested'
         $tampered=Join-Path $artifact 'CodexRemote.TrayHost.exe.config'; Add-Content -LiteralPath $tampered -Value 'x'
-        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.7' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
+        $threw=$false; try{Test-CcodTrayHostArtifact -RepositoryRoot $repositoryRoot -Version '2.5.8' -ArtifactDirectory $artifact|Out-Null}catch{$threw=$true}
         Assert-CcodTrue $threw 'tampered artifact is rejected'
     }finally{if(Test-Path -LiteralPath $artifact){Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue}}
 }
@@ -79,6 +79,23 @@ Invoke-CcodTest 'TrayHost build embeds the product ICO instead of relying on a r
     $build=Get-Content -LiteralPath (Join-Path $repositoryRoot 'build\TrayHostBuild.psm1') -Raw
     Assert-CcodTrue ($build -match 'win32icon') 'TrayHost compiler embeds an ICO'
     Assert-CcodTrue ($build -match 'codexremote-fix\.ico') 'TrayHost compiler uses the product ICO'
+}
+
+Invoke-CcodTest 'portable launcher build emits a tamper-bound double-click entrypoint' {
+    Import-Module (Join-Path $repositoryRoot 'build\TrayHostBuild.psm1') -Force
+    $artifact = Join-Path $env:TEMP ('ccod-portable-launcher-artifact-' + [Guid]::NewGuid().ToString('N'))
+    try {
+        $result = Invoke-CcodPortableLauncherBuild -RepositoryRoot $repositoryRoot -Version '2.5.8' -OutputDirectory $artifact
+        Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.Portable.exe') -PathType Leaf) 'portable launcher executable exists'
+        Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'CodexRemote.Portable.exe.config') -PathType Leaf) 'portable launcher config exists'
+        Assert-CcodTrue (Test-Path -LiteralPath (Join-Path $artifact 'portable-launcher-provenance.json') -PathType Leaf) 'portable launcher provenance exists'
+        $provenance = Get-Content -LiteralPath (Join-Path $artifact 'portable-launcher-provenance.json') -Raw | ConvertFrom-Json
+        Assert-CcodEqual '2.5.8' ([string]$provenance.version) 'portable launcher provenance version is exact'
+        $validated = (Get-FileHash -LiteralPath (Join-Path $artifact 'CodexRemote.Portable.exe') -Algorithm SHA256).Hash.ToLowerInvariant()
+        Assert-CcodEqual $validated ([string]$provenance.artifactSha256) 'portable launcher artifact binds its executable hash'
+    } finally {
+        if (Test-Path -LiteralPath $artifact) { Remove-Item -LiteralPath $artifact -Recurse -Force -ErrorAction SilentlyContinue }
+    }
 }
 
 Write-Host 'TrayHost build self-tests passed.'

--- a/tests/persistence/TrustedLogonIdentity.SelfTest.ps1
+++ b/tests/persistence/TrustedLogonIdentity.SelfTest.ps1
@@ -69,6 +69,14 @@ try {
         }
     }
 
+    Invoke-CcodTest 'default adapters return an object the strict live contract accepts' {
+        $module = Get-Module TrustedLogonIdentity | Select-Object -First 1
+        $identity = & $module { param($Value) Get-CcodTrustedLogonIdentity -Adapters $Value } $null
+        Assert-CcodEqual 'authenticationId,userSid,sessionId' (($identity.PSObject.Properties.Name) -join ',') 'default token facts are bound as an exact ordered object'
+        Assert-CcodTrue ($identity.authenticationId -cmatch '^[0-9A-F]{8}:[0-9A-F]{8}$') 'default token facts produce a canonical AuthenticationId'
+        Assert-CcodTrue ($identity.userSid -match '^S-1-(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*))+$') 'default token facts produce the current process user SID'
+    }
+
     Invoke-CcodTest 'persists and reads an exact safe-exit intent through the atomic state path' {
         $state = New-CcodSafeExitFixtureRoot -Root $root -Name 'round-trip'
         $identity = New-CcodTrustedIdentity

--- a/tests/trayhost/TrayHostNativeSelfTest.cs
+++ b/tests/trayhost/TrayHostNativeSelfTest.cs
@@ -57,9 +57,9 @@ internal static class TrayHostNativeSelfTest
     private static PresentationSnapshot SnapshotV2(ulong revision)
     {
         string[] strings = new string[] {
-            "CodexRemote-fix 2.5.7", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
+            "CodexRemote-fix 2.5.8", "Connection: Connected", "Protection: Running", "Check and repair remote connection",
             "Language / 语言", "Follow system (English)", "中文", "English", "Open logs", "About", "Exit",
-            "About", "CodexRemote-fix | Version 2.5.7", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
+            "About", "CodexRemote-fix | Version 2.5.8", "Exit CodexRemote-fix?", "Remote control will stop.", "Action failed"
         };
         return new PresentationSnapshot(revision, TrayColor.Green, ConnectionState.Connected, ProtectionState.Running, LanguageMode.English,
             PresentationFlags.LanguageEnabled | PresentationFlags.OpenLogsEnabled | PresentationFlags.AboutEnabled | PresentationFlags.ExitEnabled, strings);
@@ -147,7 +147,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform();
         TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         platform.TrackResult = 0; window.HandleContextMenu(new TrayPoint(0, 0));
-        AssertEqual("CodexRemote-fix 2.5.7|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
+        AssertEqual("CodexRemote-fix 2.5.8|Connection: Connected|Protection: Running|Check and repair remote connection|Language / 语言|Open logs|About|Exit", String.Join("|", platform.AppendedText.ToArray()), "menu contains only the approved information architecture");
         AssertTrue(!platform.AppendedText.Contains("Allow compatible update trials"), "candidate toggle is removed");
         AssertTrue(!platform.Commands.Contains(1009U), "tray uninstall command is removed");
         TrayCommand selected = TrayCommand.None; window.CommandSelected += delegate(TrayCommand command, ulong revision) { selected = command; };
@@ -163,7 +163,7 @@ internal static class TrayHostNativeSelfTest
         FakeTrayPlatform platform = new FakeTrayPlatform(); TrayWindow window = new TrayWindow(platform); window.Create(SnapshotV2(1));
         window.ShowAbout();
         AssertTrue(platform.MessageBoxes.Count == 1, "verified About shows exactly one native message box");
-        AssertEqual("About|CodexRemote-fix | Version 2.5.7", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
+        AssertEqual("About|CodexRemote-fix | Version 2.5.8", platform.MessageBoxes[0], "verified About displays the version from the acknowledged snapshot");
         window.Dispose();
     }
 

--- a/tools/Test-ReleaseDefender.ps1
+++ b/tools/Test-ReleaseDefender.ps1
@@ -303,7 +303,7 @@ function Test-CcodReleasePortablePayloadManifest {
     $checksumName = "$bundleName.sha256.txt"
     $provenanceName = "CodexRemote-fix-$ExpectedVersion-trayhost-provenance.json"
     $payloadManifestName = "CodexRemote-fix-$ExpectedVersion-payload-manifest.json"
-    $expectedNames = @($bundleName,$checksumName,$provenanceName,$payloadManifestName)
+    $expectedNames = @($bundleName,$checksumName,$provenanceName,$payloadManifestName,'CodexRemote-fix.exe','CodexRemote-fix.exe.config')
     $assetHashes = @{}
     foreach ($asset in @($ReleaseManifest.assets)) {
         if ($null -eq $asset -or (($asset.PSObject.Properties.Name | Sort-Object) -join '|') -cne 'name|sha256' -or
@@ -317,6 +317,7 @@ function Test-CcodReleasePortablePayloadManifest {
         Throw-CcodReleaseDefenderError 'CCOD_RELEASE_MANIFEST_INVALID' 'Portable release manifest does not bind the exact final asset set' $ReleaseManifestFile
     }
     foreach ($name in $expectedNames) {
+        if ($name -ceq 'CodexRemote-fix.exe' -or $name -ceq 'CodexRemote-fix.exe.config') { continue }
         $assetPath = Assert-CcodReleaseDefenderRegularFile -Path (Join-Path $Directory $name) -Kind 'Portable release asset'
         if ((Get-CcodReleaseDefenderHash -Path $assetPath) -cne $assetHashes[$name]) {
             Throw-CcodReleaseDefenderError 'CCOD_RELEASE_ASSET_HASH_MISMATCH' 'Portable release asset bytes do not match the release manifest' $name
@@ -351,7 +352,12 @@ function Test-CcodReleasePortablePayloadManifest {
         -not (Test-CcodReleaseDefenderCanonicalUtc $payloadTimestamp) -or $payloadTimestamp -cne $manifestTimestamp) {
         Throw-CcodReleaseDefenderError 'CCOD_RELEASE_MANIFEST_INVALID' 'Portable payload manifest metadata is not release-bound' $payloadManifestName
     }
-    $expectedZipFiles = @{'Install-CodexRemote-fix.ps1'=$null;'payload-manifest.json'=$null}
+    $expectedZipFiles = @{
+        'CodexRemote-fix.exe'=$null
+        'CodexRemote-fix.exe.config'=$null
+        'Install-CodexRemote-fix.ps1'=$null
+        'payload-manifest.json'=$null
+    }
     $previousPath = $null
     foreach ($record in @($payloadManifest.files)) {
         if ($null -eq $record -or (($record.PSObject.Properties.Name | Sort-Object) -join '|') -cne 'length|path|sha256' -or
@@ -369,7 +375,7 @@ function Test-CcodReleasePortablePayloadManifest {
         }
         $expectedZipFiles[$entryName] = $record
     }
-    if ($expectedZipFiles.Count -le 2) {
+    if ($expectedZipFiles.Count -le 4) {
         Throw-CcodReleaseDefenderError 'CCOD_RELEASE_MANIFEST_INVALID' 'Portable payload manifest is empty' $payloadManifestName
     }
 
@@ -407,6 +413,18 @@ function Test-CcodReleasePortablePayloadManifest {
             }
         } finally {
             if ($null -ne $manifestStream) { $manifestStream.Dispose() }
+        }
+        foreach ($rootEntryName in @('CodexRemote-fix.exe','CodexRemote-fix.exe.config')) {
+            $rootEntry = $seen[$rootEntryName]
+            $rootStream = $null
+            try {
+                $rootStream = $rootEntry.Open()
+                if ((Get-CcodReleaseDefenderStreamHash -Stream $rootStream) -cne $assetHashes[$rootEntryName]) {
+                    Throw-CcodReleaseDefenderError 'CCOD_RELEASE_ASSET_HASH_MISMATCH' 'Portable ZIP root launcher differs from the release manifest.' $rootEntryName
+                }
+            } finally {
+                if ($null -ne $rootStream) { $rootStream.Dispose() }
+            }
         }
         foreach ($entryName in @($expectedZipFiles.Keys | Where-Object { $_.StartsWith('payload/',[StringComparison]::Ordinal) })) {
             $record = $expectedZipFiles[$entryName]
@@ -551,7 +569,12 @@ function Invoke-CcodReleaseDefenderCheck {
     $versionMatch = [regex]::Match($installerLeaf, '^CodexRemote-fix-(\d+\.\d+\.\d+)-(?:setup\.exe|windows-x64\.zip)$')
     if (-not $versionMatch.Success) { Throw-CcodReleaseDefenderError 'CCOD_RELEASE_MANIFEST_INVALID' 'Release candidate name cannot bind a release manifest version' $installerLeaf }
     $version = $versionMatch.Groups[1].Value
-    $manifestPath = Join-Path (Split-Path $candidate.InstallerPath -Parent) "CodexRemote-fix-$version-release-manifest.json"
+    $manifestName = if ($installerLeaf.EndsWith('-setup.exe',[StringComparison]::Ordinal)) {
+        "CodexRemote-fix-$version-setup-release-manifest.json"
+    } else {
+        "CodexRemote-fix-$version-release-manifest.json"
+    }
+    $manifestPath = Join-Path (Split-Path $candidate.InstallerPath -Parent) $manifestName
     $manifest = Test-CcodReleaseAssetManifest -ManifestPath $manifestPath -AssetDirectory (Split-Path $candidate.InstallerPath -Parent) -ExpectedVersion $version
     if ($manifest.InstallerSha256 -cne $candidate.Sha256) { Throw-CcodReleaseDefenderError 'CCOD_RELEASE_ASSET_HASH_MISMATCH' 'Release manifest and checksum bind different installer bytes' $installerLeaf }
     $zone = & $adapters.GetZoneId $candidate.InstallerPath


### PR DESCRIPTION
Publish both the Inno Setup installer and portable ZIP. The portable ZIP now includes a double-click CodexRemote-fix.exe launcher instead of a PowerShell script. Includes the live supervisor startup fix.